### PR TITLE
Adding the ability to define multiple hooks in an array.

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 var utils = require('./utils');
 
 module.exports = function(service) {
-  if(typeof service.mixin !== 'function') {
+  if(!_.isFunction(service.mixin)) {
     return;
   }
 
@@ -11,61 +11,79 @@ module.exports = function(service) {
 
   service.mixin({
     after: function(obj) {
-      var mixin = _.transform(obj, function(result, hook, name) {
+      var mixin = _.transform(obj, function(result, hooks, name) {
         // Don't mix in if it is not a service method
         if(app.methods.indexOf(name) === -1) {
           return;
+        }          
+
+        if (!_.isArray(hooks)){
+          hooks = [hooks];
         }
 
-        result[name] = function() {
-          var self = this;
-          var args = _.toArray(arguments);
-          var hookObject = utils.hookObject(name, args);
-          // The callback for the after hook
-          var hookCallback = function(error, newHookObject) {
-            // Call the callback with the result we set in `newCallback`
-            var hook = newHookObject || hookObject;
+        result[name] = [];
+        
+        _.each(hooks, function(hook){
+          var fn = function() {
+            var self = this;
+            var args = _.toArray(arguments);
+            var hookObject = utils.hookObject(name, args);
+            // The callback for the after hook
+            var hookCallback = function(error, newHookObject) {
+              // Call the callback with the result we set in `newCallback`
+              var hook = newHookObject || hookObject;
 
-            if(error) {
-              // Call the old callback with the hook error
-              return hook.callback(error);
-            }
+              if(error) {
+                // Call the old callback with the hook error
+                return hook.callback(error);
+              }
 
-            hook.callback(null, hook.result);
+              hook.callback(null, hook.result);
+            };
+            // The new _super method callback
+            var newCallback = function(error, result) {
+              if(error) {
+                // Call the old callback with the error
+                return hookObject.callback(error);
+              }
+
+              // Set hookObject result
+              hookObject.result = result;
+
+              // Call the hook object
+              var promise = hook.call(self, hookObject, hookCallback);
+              if(typeof promise !== 'undefined' && typeof promise.then === 'function') {
+                promise.then(function() {
+                  hookCallback();
+                }, function(error) {
+                  hookCallback(error);
+                });
+              }
+            };
+
+            hookObject.type = 'after';
+
+            // Remove the old callback and replace with the new callback that runs the hook
+            args.pop();
+            args.push(newCallback);
+
+            // Call super method
+            return this._super.apply(this, args);
           };
-          // The new _super method callback
-          var newCallback = function(error, result) {
-            if(error) {
-              // Call the old callback with the error
-              return hookObject.callback(error);
-            }
 
-            // Set hookObject result
-            hookObject.result = result;
-
-            // Call the hook object
-            var promise = hook.call(self, hookObject, hookCallback);
-            if(typeof promise !== 'undefined' && typeof promise.then === 'function') {
-              promise.then(function() {
-                hookCallback();
-              }, function(error) {
-                hookCallback(error);
-              });
-            }
-          };
-
-          hookObject.type = 'after';
-
-          // Remove the old callback and replace with the new callback that runs the hook
-          args.pop();
-          args.push(newCallback);
-
-          // Call super method
-          return this._super.apply(this, args);
-        };
+          result[name].push(fn);
+        });
       });
 
-      this.mixin(mixin);
+      var self = this;
+
+      _.each(mixin, function(hooks, method){
+        _.each(hooks, function(hook){
+          var obj = {};
+          obj[method] = hook;
+          self.mixin(obj);
+        });
+      });
 
       return this;
     }

--- a/lib/before.js
+++ b/lib/before.js
@@ -1,8 +1,10 @@
+
+
 var _ = require('lodash');
 var utils = require('./utils');
 
 module.exports = function(service) {
-  if(typeof service.mixin !== 'function') {
+  if (!_.isFunction(service.mixin)) {
     return;
   }
 
@@ -11,44 +13,62 @@ module.exports = function(service) {
 
   service.mixin({
     before: function(obj) {
-      var mixin = _.transform(obj, function(result, hook, name) {
+      var mixin = _.transform(obj, function(result, hooks, name) {
         // Don't mix in if it is not a service method
         if(app.methods.indexOf(name) === -1) {
           return;
         }
 
-        result[name] = function() {
-          var self = this;
-          // The original method
-          var _super = this._super;
-          // The hook data object
-          var hookObject = utils.hookObject(name, arguments);
-          // The callback for the hook
-          var hookCallback = function(error, newHookObject) {
-            if(error) {
-              // We got an error
-              return hookObject.callback(error);
-            }
+        if (!_.isArray(hooks)){
+          hooks = [hooks];
+        }
 
-            // Call the _super method. We either use the original hook object
-            // to create the arguments or the new one passed to the hook callback
-            _super.apply(self, utils.makeArguments(newHookObject || hookObject));
+        result[name] = [];
+
+        _.each(hooks, function(hook){
+          var fn = function() {
+            var self = this;
+            // The original method
+            var _super = this._super;
+            // The hook data object
+            var hookObject = utils.hookObject(name, arguments);
+            // The callback for the hook
+            var hookCallback = function(error, newHookObject) {
+              if(error) {
+                // We got an error
+                return hookObject.callback(error);
+              }
+
+              // Call the _super method. We either use the original hook object
+              // to create the arguments or the new one passed to the hook callback
+              _super.apply(self, utils.makeArguments(newHookObject || hookObject));
+            };
+
+            hookObject.type = 'before';
+
+            var promise = hook.call(self, hookObject, hookCallback);
+            if(typeof promise !== 'undefined' && typeof promise.then === 'function') {
+              promise.then(function() {
+                hookCallback();
+              }, function(error) {
+                hookCallback(error);
+              });
+            }
           };
 
-          hookObject.type = 'before';
-
-          var promise = hook.call(self, hookObject, hookCallback);
-          if(typeof promise !== 'undefined' && typeof promise.then === 'function') {
-            promise.then(function() {
-              hookCallback();
-            }, function(error) {
-              hookCallback(error);
-            });
-          }
-        };
+          result[name].push(fn);
+        });
       });
+       
+      var self = this;
 
-      this.mixin(mixin);
+      _.each(mixin, function(hooks, method){
+        _.each(hooks, function(hook){
+          var obj = {};
+          obj[method] = hook;
+          self.mixin(obj);
+        });
+      });
 
       return this;
     }

--- a/test/after.test.js
+++ b/test/after.test.js
@@ -77,7 +77,7 @@ describe('.after hooks', function() {
     });
   });
 
-  it('adds .after() and chains multiple calls', function(done) {
+  it('adds .after() and chains multiple hooks for the same method', function(done) {
     var dummyService = {
       create: function(data, params, callback) {
         callback(null, data);
@@ -103,6 +103,42 @@ describe('.after hooks', function() {
     });
 
     service.create({ my: 'data' }, {}, function(error, data) {
+      assert.deepEqual({
+        my: 'data',
+        some: 'thing',
+        other: 'stuff'
+      }, data, 'Got modified data');
+      done();
+    });
+  });
+
+  it('chains multiple after hooks using array syntax', function(done) {
+    var dummyService = {
+      create: function(data, params, callback) {
+        callback(null, data);
+      }
+    };
+
+    var app = feathers().configure(hooks()).use('/dummy', dummyService);
+    var service = app.lookup('dummy');
+
+    service.after({
+      create: [
+        function(hook, next) {
+          hook.result.some = 'thing';
+          next();
+        },
+        function(hook, next) {
+          hook.result.other = 'stuff';
+
+          next();
+        }
+      ]
+    });
+
+    service.create({ my: 'data' }, {}, function(error, data) {
+      console.log('DATA', data);
+        
       assert.deepEqual({
         my: 'data',
         some: 'thing',


### PR DESCRIPTION
This PR gives the ability to define hooks like so:

``` js
var hooks = require('../hook-library.js');

service.before({
  // Use hooks the same way as before with a singular function
  index: hooks.requireAuthAllowPublic,

  // Chain multiple hooks together
  create : [hooks.requireAuth, hooks.setUserID, hooks.setCreatedAt]
});
```

You can still add hooks the exact same way you have always been able to.
