### PR TITLE
removing service method check so we can add hooks to custom methods

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -7,15 +7,10 @@ module.exports = function(service) {
   }
 
   var oldAfter = service.after;
-  var app = this;
 
   service.mixin({
     after: function(obj) {
       var mixin = _.transform(obj, function(result, hooks, name) {
-        // Don't mix in if it is not a service method
-        if(app.methods.indexOf(name) === -1) {
-          return;
-        }          
 
         if (!_.isArray(hooks)){
           hooks = [hooks];
@@ -81,6 +76,7 @@ module.exports = function(service) {
         _.each(hooks, function(hook){
           var obj = {};
           obj[method] = hook;
+          console.log("OBJECT", obj);
           self.mixin(obj);
         });
       });

--- a/lib/before.js
+++ b/lib/before.js
@@ -14,10 +14,6 @@ module.exports = function(service) {
   service.mixin({
     before: function(obj) {
       var mixin = _.transform(obj, function(result, hooks, name) {
-        // Don't mix in if it is not a service method
-        if(app.methods.indexOf(name) === -1) {
-          return;
-        }
 
         if (!_.isArray(hooks)){
           hooks = [hooks];


### PR DESCRIPTION
I'm not where we can really do the check to see if the original service method exists since we don't have context for `this._super`. Possibly we could add the check [here](https://github.com/feathersjs/feathers-hooks/blob/master/lib/after.js#L74) but then the hook will still get added. It will just never call the super method.