### PR TITLE
Refactoring to fix hook execution order and all-hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2014 David Luecke
+Copyright 2015 David Luecke
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/after.js
+++ b/lib/after.js
@@ -1,95 +1,66 @@
+'use strict';
+
 var _ = require('lodash');
 var utils = require('./utils');
+var commons = require('./commons');
 
-module.exports = function(service) {
-  if(!_.isFunction(service.mixin)) {
-    return;
+/**
+ * Return the hook mixin method for the given name.
+ *
+ * @param {String} method The service method name
+ * @returns {Function}
+ */
+var getMixin = function (method) {
+  return function() {
+    var _super = this._super;
+
+    if(!this.__after || !this.__after[method].length) {
+      return _super.apply(this, arguments);
+    }
+
+    var args = _.toArray(arguments);
+    var hookObject = utils.hookObject(method, 'after', args);
+    // Make a copy of our hooks
+    var hooks = this.__after[method].slice();
+
+    // Remove the old callback and replace with the new callback that runs the hook
+    args.pop();
+    // The new _super method callback
+    args.push(function(error, result) {
+      if(error) {
+        // Call the old callback with the error
+        return hookObject.callback(error);
+      }
+
+      var fn = function(hookObject) {
+        return hookObject.callback(null, hookObject.result);
+      };
+
+      // Set hookObject result
+      hookObject.result = result;
+
+      while(hooks.length) {
+        fn = commons.makeHookFn(hooks.pop(), fn);
+      }
+
+      return fn.call(this, hookObject);
+    }.bind(this));
+
+
+    return _super.apply(this, args);
+  };
+};
+
+var addHooks = function(hooks, method) {
+  var myHooks = this.__after[method];
+
+  if(hooks[method]) {
+    myHooks.push.apply(myHooks, hooks[method]);
   }
 
-  var oldAfter = service.after;
-  var app = this;
-
-  service.mixin({
-    after: function(obj) {
-      var mixin = _.transform(obj, function(result, hooks, name) {
-        // Don't mix in if it is not a service method
-        if(app.methods.indexOf(name) === -1) {
-          return;
-        }          
-
-        if (!_.isArray(hooks)){
-          hooks = [hooks];
-        }
-
-        result[name] = [];
-        
-        _.each(hooks, function(hook){
-          var fn = function() {
-            var self = this;
-            var args = _.toArray(arguments);
-            var hookObject = utils.hookObject(name, args);
-            // The callback for the after hook
-            var hookCallback = function(error, newHookObject) {
-              // Call the callback with the result we set in `newCallback`
-              var hook = newHookObject || hookObject;
-
-              if(error) {
-                // Call the old callback with the hook error
-                return hook.callback(error);
-              }
-
-              hook.callback(null, hook.result);
-            };
-            // The new _super method callback
-            var newCallback = function(error, result) {
-              if(error) {
-                // Call the old callback with the error
-                return hookObject.callback(error);
-              }
-
-              // Set hookObject result
-              hookObject.result = result;
-
-              // Call the hook object
-              var promise = hook.call(self, hookObject, hookCallback);
-              if(typeof promise !== 'undefined' && typeof promise.then === 'function') {
-                promise.then(function() {
-                  hookCallback();
-                }, function(error) {
-                  hookCallback(error);
-                });
-              }
-            };
-
-            hookObject.type = 'after';
-
-            // Remove the old callback and replace with the new callback that runs the hook
-            args.pop();
-            args.push(newCallback);
-
-            // Call super method
-            return this._super.apply(this, args);
-          };
-
-          result[name].push(fn);
-        });
-      });
-
-      var self = this;
-
-      _.each(mixin, function(hooks, method){
-        _.each(hooks, function(hook){
-          var obj = {};
-          obj[method] = hook;
-          self.mixin(obj);
-        });
-      });
-
-      return this;
-    }
-  });
-
-  if(oldAfter) {
-    service.after(oldAfter);
+  if(hooks.all) {
+    myHooks.push.apply(myHooks, hooks.all);
   }
 };
+
+module.exports = commons.createMixin('after', getMixin, addHooks);

--- a/lib/before.js
+++ b/lib/before.js
@@ -1,80 +1,47 @@
+'use strict';
 
-
-var _ = require('lodash');
 var utils = require('./utils');
+var commons = require('./commons');
 
-module.exports = function(service) {
-  if (!_.isFunction(service.mixin)) {
-    return;
+/**
+ * Return the hook mixin method for the given name.
+ *
+ * @param {String} method The service method name
+ * @returns {Function}
+ */
+var getMixin = function (method) {
+  return function() {
+    var _super = this._super;
+
+    if(!this.__before || !this.__before[method].length) {
+      return _super.apply(this, arguments);
+    }
+
+    // Make a copy of our hooks
+    var hooks = this.__before[method].slice();
+    // The chained function
+    var fn = function(hookObject) {
+      return _super.apply(this, utils.makeArguments(hookObject));
+    };
+
+    while(hooks.length) {
+      fn = commons.makeHookFn(hooks.pop(), fn);
+    }
+
+    return fn.call(this, utils.hookObject(method, 'before', arguments));
+  };
+};
+
+var addHooks = function(hooks, method) {
+  var myHooks = this.__before[method];
+
+  if(hooks.all) {
+    myHooks.push.apply(myHooks, hooks.all);
   }
 
-  var app = this;
-  var oldBefore = service.before;
-
-  service.mixin({
-    before: function(obj) {
-      var mixin = _.transform(obj, function(result, hooks, name) {
-        // Don't mix in if it is not a service method
-        if(app.methods.indexOf(name) === -1) {
-          return;
-        }
-
-        if (!_.isArray(hooks)){
-          hooks = [hooks];
-        }
-
-        result[name] = [];
-
-        _.each(hooks, function(hook){
-          var fn = function() {
-            var self = this;
-            // The original method
-            var _super = this._super;
-            // The hook data object
-            var hookObject = utils.hookObject(name, arguments);
-            // The callback for the hook
-            var hookCallback = function(error, newHookObject) {
-              if(error) {
-                // We got an error
-                return hookObject.callback(error);
-              }
-
-              // Call the _super method. We either use the original hook object
-              // to create the arguments or the new one passed to the hook callback
-              _super.apply(self, utils.makeArguments(newHookObject || hookObject));
-            };
-
-            hookObject.type = 'before';
-
-            var promise = hook.call(self, hookObject, hookCallback);
-            if(typeof promise !== 'undefined' && typeof promise.then === 'function') {
-              promise.then(function() {
-                hookCallback();
-              }, function(error) {
-                hookCallback(error);
-              });
-            }
-          };
-
-          result[name].push(fn);
-        });
-      });
-       
-      var self = this;
-
-      _.each(mixin, function(hooks, method){
-        _.each(hooks, function(hook){
-          var obj = {};
-          obj[method] = hook;
-          self.mixin(obj);
-        });
-      });
-
-      return this;
-    }
-  });
-
-  if(oldBefore) {
-    service.before(oldBefore);
+  if(hooks[method]) {
+    myHooks.push.apply(myHooks, hooks[method]);
   }
 };
+
+module.exports = commons.createMixin('before', getMixin, addHooks);

--- a/lib/commons.js
+++ b/lib/commons.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var _ = require('lodash');
+var utils = require('./utils');
+
+/**
+ * Creates a new hook function for the execution chain.
+ *
+ * @param {Function} hook The hook function
+ * @param {Function} prev The previous hook method in the chain
+ * @returns {Function}
+ */
+exports.makeHookFn = function(hook, prev) {
+  return function(hookObject) {
+    // The callback for the hook
+    var hookCallback = function(error, newHookObject) {
+      var currentHook = newHookObject || hookObject;
+
+      // Call the callback with the result we set in `newCallback`
+      if(error) {
+        // Call the old callback with the hook error
+        return currentHook.callback(error);
+      }
+
+      prev.call(this, currentHook);
+    };
+
+    var promise = hook.call(this, hookObject, hookCallback);
+
+    if(typeof promise !== 'undefined' && typeof promise.then === 'function') {
+      promise.then(function() {
+        hookCallback();
+      }, function(error) {
+        hookCallback(error);
+      });
+    }
+
+    return promise;
+  };
+};
+
+/**
+ * Returns the main mixin function for the given type.
+ *
+ * @param {String} type The type of the hook (currently `before` and `after`)
+ * @param {Function} getMixin A function that returns the actual
+ * mixin function.
+ * @param {Function} addHooks A callback that adds the hooks
+ * @returns {Function}
+ */
+exports.createMixin = function(type, getMixin, addHooks) {
+  return function(service) {
+    if(!_.isFunction(service.mixin)) {
+      return;
+    }
+
+    var app = this;
+    var hookProp = '__' + type;
+    var methods = app.methods;
+    var old = service[type];
+
+    var mixin = {};
+
+    mixin[type] = function(obj) {
+      if(!this[hookProp]) {
+        this[hookProp] = {};
+        _.each(methods, function(method) {
+          this[hookProp][method] = [];
+        }.bind(this));
+      }
+
+      _.each(methods, addHooks.bind(this, utils.convertHookData(obj)));
+
+      return this;
+    };
+
+    _.each(methods, function(method) {
+      if(typeof service[method] !== 'function') {
+        return;
+      }
+
+      mixin[method] = getMixin(method);
+    });
+
+    service.mixin(mixin);
+
+    if(old) {
+      service[type](old);
+    }
+  };
+};

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,10 +1,3 @@
-/*
- * feathers-hooks
- *
- * Copyright (c) 2014 David Luecke
- * Licensed under the MIT license.
- */
-
 'use strict';
 
 var before = require('./before');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,7 @@
+'use strict';
+
+var _ = require('lodash');
+
 function getOrRemove(args) {
   return {
     id: args[0],
@@ -35,9 +39,11 @@ exports.converters = {
   patch: updateOrPatch
 };
 
-exports.hookObject = function(method, args) {
+exports.hookObject = function(method, type, args) {
   var hook = exports.converters[method](args);
+
   hook.method = method;
+  hook.type = type;
 
   return hook;
 };
@@ -56,4 +62,20 @@ exports.makeArguments = function(hookObject) {
   result.push(hookObject.callback);
 
   return result;
+};
+
+exports.convertHookData = function(obj) {
+  var hookObject = {};
+
+  if(_.isArray(obj)) {
+    hookObject = { all: obj };
+  } else if(typeof obj !== 'object') {
+    hookObject = { all: [ obj ] };
+  } else {
+    _.each(obj, function(value, key) {
+      hookObject[key] = !_.isArray(value) ? [ value ] : value;
+    });
+  }
+
+  return hookObject;
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,7 +5,7 @@ var utils = require('../lib/utils');
 
 function hookMaker(name) {
   return function() {
-    return utils.hookObject(name, arguments);
+    return utils.hookObject(name, 'test', arguments);
   };
 }
 
@@ -15,6 +15,7 @@ describe('hook utilities', function() {
     assert.deepEqual(hookMaker('find')({ some: 'thing' }, _.noop), {
       params: { some: 'thing' },
       method: 'find',
+      type: 'test',
       callback: _.noop
     });
 
@@ -23,6 +24,7 @@ describe('hook utilities', function() {
       id: 1,
       params: { some: 'thing' },
       method: 'get',
+      type: 'test',
       callback: _.noop
     });
 
@@ -31,6 +33,7 @@ describe('hook utilities', function() {
       id: 1,
       params: { some: 'thing' },
       method: 'remove',
+      type: 'test',
       callback: _.noop
     });
 
@@ -39,6 +42,7 @@ describe('hook utilities', function() {
       data: { my: 'data' },
       params: { some: 'thing' },
       method: 'create',
+      type: 'test',
       callback: _.noop
     });
 
@@ -48,6 +52,7 @@ describe('hook utilities', function() {
       data: { my: 'data' },
       params: { some: 'thing' },
       method: 'update',
+      type: 'test',
       callback: _.noop
     });
 
@@ -57,6 +62,7 @@ describe('hook utilities', function() {
       data: { my: 'data' },
       params: { some: 'thing' },
       method: 'patch',
+      type: 'test',
       callback: _.noop
     });
   });
@@ -92,5 +98,25 @@ describe('hook utilities', function() {
       { some: 'thing' },
       _.noop
     ]);
+  });
+
+  it('.convertHookData', function() {
+    assert.deepEqual(utils.convertHookData('test'), {
+      all: [ 'test' ]
+    });
+
+    assert.deepEqual(utils.convertHookData([ 'test', 'me' ]), {
+      all: [ 'test', 'me' ]
+    });
+
+    assert.deepEqual(utils.convertHookData({
+      all: 'thing',
+      other: 'value',
+      hi: [ 'foo', 'bar' ]
+    }), {
+      all: [ 'thing' ],
+      other: [ 'value' ],
+      hi: [ 'foo', 'bar' ]
+    });
   });
 });


### PR DESCRIPTION
This pull request is a bigger refactoring that fixes the hook execution order (closes #13) and adds support for before-all and after-all hooks (closes #11). New tests added and old tests didn't need to be changed (so we can assume backwards compatibility).