### PR TITLE
Make sure hooks and service methods keep their context

### DIFF
--- a/lib/commons.js
+++ b/lib/commons.js
@@ -23,7 +23,7 @@ exports.makeHookFn = function(hook, prev) {
       }
 
       prev.call(this, currentHook);
-    };
+    }.bind(this);
 
     var promise = hook.call(this, hookObject, hookCallback);
 

--- a/test/after.test.js
+++ b/test/after.test.js
@@ -275,4 +275,34 @@ describe('.after hooks', function() {
       });
     });
   });
+
+  it('after hooks have service as context and keep it in service method (#17)', function(done) {
+    var app = feathers().configure(hooks()).use('/dummy', {
+      number: 42,
+      get: function(id, params, callback) {
+        callback(null, {
+          id: id,
+          number: this.number
+        });
+      }
+    });
+
+    var service = app.service('dummy');
+
+    service.after({
+      get: function(hook, next) {
+        hook.result.test = this.number + 1;
+        next();
+      }
+    });
+
+    service.get(10, {}, function(error, data) {
+      assert.deepEqual(data, {
+        id: 10,
+        number: 42,
+        test: 43
+      });
+      done();
+    });
+  });
 });

--- a/test/before.test.js
+++ b/test/before.test.js
@@ -299,4 +299,35 @@ describe('.before hooks', function() {
       service.get(1, {}, done);
     });
   });
+
+  it('before hooks have service as context and keep it in service method (#17)', function(done) {
+    var app = feathers().configure(hooks()).use('/dummy', {
+      number: 42,
+      get: function(id, params, callback) {
+        callback(null, {
+          id: id,
+          number: this.number,
+          test: params.test
+        });
+      }
+    });
+
+    var service = app.service('dummy');
+
+    service.before({
+      get: function(hook, next) {
+        hook.params.test = this.number + 2;
+        next();
+      }
+    });
+
+    service.get(10, {}, function(error, data) {
+      assert.deepEqual(data, {
+        id: 10,
+        number: 42,
+        test: 44
+      });
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This pull request makes sure that hooks don't loose the service as the context. Closes #17.