### PR TITLE
Handle advanced rest routes for collection in resource

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,16 @@ function updateOrPatch(args) {
   };
 }
 
+function removeOrGetInCollection(args) {
+  return {
+    id: args[0],
+    collection: args[1],
+    documentId: args[2],
+    params: args[3],
+    callback: args[4]
+  };
+}
+
 exports.converters = {
   find: function(args) {
     return {
@@ -36,7 +46,26 @@ exports.converters = {
   get: getOrRemove,
   remove: getOrRemove,
   update: updateOrPatch,
-  patch: updateOrPatch
+  patch: updateOrPatch,
+  findInCollection: function(args) {
+    return {
+      id: args[0],
+      collection: args[1],
+      params: args[2],
+      callback: args[3]
+    };
+  },
+  addToCollection: function(args) {
+    return {
+      id: args[0],
+      collection: args[1],
+      data: args[2],
+      params: args[3],
+      callback: args[4]
+    };
+  },
+  getInCollection: removeOrGetInCollection,
+  removeFromCollection: removeOrGetInCollection
 };
 
 exports.hookObject = function(method, type, args) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,8 +83,16 @@ exports.makeArguments = function(hookObject) {
     result.push(hookObject.id);
   }
 
+  if (hookObject.collection) {
+    result.push(hookObject.collection);
+  }
+
   if(hookObject.data) {
     result.push(hookObject.data);
+  }
+
+  if (typeof hookObject.documentId !== 'undefined') {
+    result.push(hookObject.documentId);
   }
 
   result.push(hookObject.params || {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-hooks",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Before and after service method call hooks for easy authorization and processing.",
   "homepage": "https://github.com/feathersjs/feathers-hooks",
   "keywords": [

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -65,6 +65,49 @@ describe('hook utilities', function() {
       type: 'test',
       callback: _.noop
     });
+
+    // find in collection
+    assert.deepEqual(hookMaker('findInCollection')(3, 'tasks', { some: 'thing' }, _.noop), {
+      id: 3,
+      collection: 'tasks',
+      params: { some: 'thing' },
+      method: 'findInCollection',
+      type: 'test',
+      callback: _.noop
+    });
+
+    // get in collection
+    assert.deepEqual(hookMaker('getInCollection')(4, 'tasks', 123, { some: 'thing' }, _.noop), {
+      id: 4,
+      collection: 'tasks',
+      documentId: 123,
+      params: { some: 'thing' },
+      method: 'getInCollection',
+      type: 'test',
+      callback: _.noop
+    });
+
+    // remove from collection
+    assert.deepEqual(hookMaker('removeFromCollection')(4, 'tasks', 123, { some: 'thing' }, _.noop), {
+      id: 4,
+      collection: 'tasks',
+      documentId: 123,
+      params: { some: 'thing' },
+      method: 'removeFromCollection',
+      type: 'test',
+      callback: _.noop
+    });
+
+    // add to collection
+    assert.deepEqual(hookMaker('addToCollection')(3, 'tasks', { my: 'data' }, { some: 'thing' }, _.noop), {
+      id: 3,
+      collection: 'tasks',
+      data: { my: 'data' },
+      params: { some: 'thing' },
+      method: 'addToCollection',
+      type: 'test',
+      callback: _.noop
+    });
   });
 
   it('.makeArguments', function() {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -141,6 +141,38 @@ describe('hook utilities', function() {
       { some: 'thing' },
       _.noop
     ]);
+
+    args = utils.makeArguments({
+      id: 5,
+      collection: 'tasks',
+      params: { some: 'thing' },
+      method: 'findInCollection',
+      callback: _.noop
+    });
+
+    assert.deepEqual(args, [5, 'tasks', { some: 'thing' }, _.noop]);
+
+    args = utils.makeArguments({
+      id: 6,
+      collection: 'tasks',
+      data: { my: 'data' },
+      params: { some: 'thing' },
+      method: 'addToCollection',
+      callback: _.noop
+    });
+
+    assert.deepEqual(args, [6, 'tasks', { my: 'data' }, { some: 'thing' }, _.noop]);
+
+    args = utils.makeArguments({
+      id: 7,
+      collection: 'tasks',
+      documentId: 123,
+      params: { some: 'thing' },
+      method: 'removeFromCollection',
+      callback: _.noop
+    });
+
+    assert.deepEqual(args, [7, 'tasks', 123, { some: 'thing' }, _.noop]);
   });
 
   it('.convertHookData', function() {


### PR DESCRIPTION
Handle new routes for updating a collection within a resource:
- Find an item within the collection:
  [GET] /:id/:collection 
  --> service.findInCollection(id, collection, params, cb)
- Get an item of the collection
  [GET] /:id/:collection/:documentId 
  --> service.getInCollection(id, collection, documentId, params, cb)
- Add an item to the collection
  [POST] /:id/:collection 
  --> service.addToCollection(id, collection, data, params, cb)
- Remove an item from the collection
  [DELETE] /:id/:collection/:documentId 
  --> service.removeFromCollection(id, collection, documentId, params, cb)

Linked with these PRs:
- feathers: https://github.com/feathersjs/feathers/pull/141
- feathers-commons: https://github.com/feathersjs/feathers-commons/pull/2
