### PR TITLE
Prevent next from being called multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lib": "lib"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "feathers-commons": "^0.5.0"
   },
   "devDependencies": {

--- a/src/after.js
+++ b/src/after.js
@@ -1,5 +1,8 @@
+import makeDebug from 'debug';
 import { hooks as utils } from 'feathers-commons';
 import { makeHookFn, createMixin } from './commons';
+
+const debug = makeDebug('feathers-hooks:after');
 
 /**
  * Return the hook mixin method for the given name.
@@ -17,8 +20,10 @@ function getMixin(method) {
 
     const args = Array.from(arguments);
     const hookObject = utils.hookObject(method, 'after', args);
+
     // Make a copy of our hooks
     const hooks = this.__after[method].slice();
+    debug(`Running ${hooks.length} after hooks for method ${method}`);
 
     // Remove the old callback and replace with the new callback that runs the hook
     args.pop();

--- a/src/before.js
+++ b/src/before.js
@@ -1,5 +1,8 @@
+import makeDebug from 'debug';
 import { hooks as utils } from 'feathers-commons';
 import { makeHookFn, createMixin } from './commons';
+
+const debug = makeDebug('feathers-hooks:before');
 
 /**
  * Return the hook mixin method for the given name.
@@ -17,6 +20,8 @@ function getMixin(method) {
 
     // Make a copy of our hooks
     const hooks = this.__before[method].slice();
+    debug(`Running ${hooks.length} before hooks for method ${method}`);
+
     // The chained function
     let fn = function(hookObject) {
       return _super.apply(this, utils.makeArguments(hookObject));
@@ -31,7 +36,7 @@ function getMixin(method) {
 }
 
 function addHooks(hooks, method) {
-  var myHooks = this.__before[method];
+  const myHooks = this.__before[method];
 
   if(hooks.all) {
     myHooks.push.apply(myHooks, hooks.all);

--- a/test/after.test.js
+++ b/test/after.test.js
@@ -298,4 +298,33 @@ describe('.after hooks', () => {
       done();
     });
   });
+
+  it('can not call next() multiple times', () => {
+    const app = feathers().configure(hooks()).use('/dummy', {
+      get(id, params, callback) {
+        callback(null, { id });
+      }
+    });
+
+    const service = app.service('dummy');
+
+    service.after({
+      get: [
+        function(hook, next) {
+          next();
+        },
+
+        function(hook, next) {
+          next();
+          next();
+        }
+      ]
+    });
+
+    try {
+      service.get(10);
+    } catch(e) {
+      assert.deepEqual(e.message, `next() called multiple times for hook on 'get' method`);
+    }
+  });
 });

--- a/test/before.test.js
+++ b/test/before.test.js
@@ -318,4 +318,33 @@ describe('.before hooks', () => {
       done();
     });
   });
+
+  it('can not call next() multiple times', () => {
+    const app = feathers().configure(hooks()).use('/dummy', {
+      get(id, params, callback) {
+        callback(null, { id });
+      }
+    });
+
+    const service = app.service('dummy');
+
+    service.before({
+      get: [
+        function(hook, next) {
+          next();
+        },
+
+        function(hook, next) {
+          next();
+          next();
+        }
+      ]
+    });
+
+    try {
+      service.get(10);
+    } catch(e) {
+      assert.deepEqual(e.message, `next() called multiple times for hook on 'get' method`);
+    }
+  });
 });


### PR DESCRIPTION
`next()` should only be called once in a hook and not preventing it led to some hard to debug errors. This now throws an error.