### PR TITLE
Refactoring for hooks to use promises and promise chains

### DIFF
--- a/examples/authorization.js
+++ b/examples/authorization.js
@@ -49,24 +49,20 @@ var todoService = app.service('todos');
 
 // This `before` hook checks if a user is set
 todoService.before({
-	find: function(hook, next) {
+	find: function(hook) {
 		// If no user is set, throw an error
 		if(!hook.params.user) {
-			return next(new Error('You are not authorized. Set the ?user=username parameter.'));
+			throw new Error('You are not authorized. Set the ?user=username parameter.');
 		}
-
-		next();
 	}
 });
 
 // This `after` hook sets the username for each Todo
 todoService.after({
-	find: function(hook, next) {
+	find: function(hook) {
 		hook.result.forEach(function(todo) {
 			todo.user = hook.params.user.name;
 		});
-
-		next();
 	}
 });
 

--- a/examples/timestamp.js
+++ b/examples/timestamp.js
@@ -52,16 +52,12 @@ var todoService = app.service('todos');
 
 // Register a hook that adds a createdAt and updatedAt timestamp
 todoService.before({
-	create: function(hook, next) {
+	create: function(hook) {
 		hook.data.createdAt = new Date();
-
-		next();
 	},
 
-	update: function(hook, next) {
+	update: function(hook) {
 		hook.data.updatedAt = new Date();
-
-		next();
 	}
 });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lib": "lib"
   },
   "dependencies": {
-    "debug": "^2.2.0",
     "feathers-commons": "^0.5.0"
   },
   "devDependencies": {

--- a/test/after.test.js
+++ b/test/after.test.js
@@ -4,327 +4,381 @@ import feathers from 'feathers';
 import hooks from '../lib/hooks';
 
 describe('.after hooks', () => {
-  it('gets mixed into a service and modifies data', done => {
-    const dummyService = {
-      after: {
+  describe('function(hook)', () => {
+    it('returning a non-hook object throws error', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id) {
+          return Promise.resolve({ id });
+        },
+
+        after: {
+          get() {
+            return {};
+          }
+        }
+      });
+      const service = app.service('dummy');
+
+      service.get(10).catch(e => {
+        assert.equal(e.message, 'after hook for \'get\' method returned invalid hook object');
+        done();
+      });
+    });
+
+    it('.after hooks can return a promise', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id) {
+          return Promise.resolve({
+            id: id,
+            description: `You have to do ${id}`
+          });
+        },
+
+        find() {
+          return Promise.resolve([]);
+        }
+      });
+      const service = app.service('dummy');
+
+      service.after({
+        get(hook) {
+          hook.result.ran = true;
+          return Promise.resolve(hook);
+        },
+
+        find() {
+          return Promise.reject(new Error('You can not see this'));
+        }
+      });
+
+      service.get('laundry', {}, (error, data) => {
+        assert.deepEqual(data, {
+          id: 'laundry',
+          description: 'You have to do laundry',
+          ran: true
+        });
+        service.find({}, error => {
+          assert.equal(error.message, 'You can not see this');
+          done();
+        });
+      });
+    });
+
+    it('.after hooks do not need to return anything', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id) {
+          return Promise.resolve({
+            id, description: `You have to do ${id}`
+          });
+        },
+
+        find() {
+          return Promise.resolve([]);
+        }
+      });
+      const service = app.service('dummy');
+
+      service.after({
+        get(hook) {
+          hook.result.ran = true;
+        },
+
+        find() {
+          throw new Error('You can not see this');
+        }
+      });
+
+      service.get('laundry').then(data => {
+        assert.deepEqual(data, {
+          id: 'laundry',
+          description: 'You have to do laundry',
+          ran: true
+        });
+
+        service.find().catch(error => {
+          assert.equal(error.message, 'You can not see this');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('function(hook, next)', () => {
+    it('gets mixed into a service and modifies data', done => {
+      const dummyService = {
+        after: {
+          create(hook, next) {
+            assert.equal(hook.type, 'after');
+
+            hook.result.some = 'thing';
+
+            next(null, hook);
+          }
+        },
+
+        create(data, params, callback) {
+          callback(null, data);
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
+
+      service.create({ my: 'data' }, {}, (error, data) => {
+        assert.deepEqual({ my: 'data', some: 'thing' }, data, 'Got modified data');
+        done();
+      });
+    });
+
+    it('returns errors', done => {
+      const dummyService = {
+        after: {
+          update(hook, next) {
+            next(new Error('This did not work'));
+          }
+        },
+
+        update(id, data, params, callback) {
+          callback(null, data);
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
+
+      service.update(1, { my: 'data' }, {}, error => {
+        assert.ok(error, 'Got an error');
+        assert.equal(error.message, 'This did not work', 'Got expected error message from hook');
+        done();
+      });
+    });
+
+    it('does not run after hook when there is an error', done => {
+      const dummyService = {
+        after: {
+          remove() {
+            assert.ok(false, 'This should never get called');
+          }
+        },
+
+        remove(id, params, callback) {
+          callback(new Error('Error removing item'));
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
+
+      service.remove(1, {}, error => {
+        assert.ok(error, 'Got error');
+        assert.equal(error.message, 'Error removing item', 'Got error message from service');
+        done();
+      });
+    });
+
+    it('adds .after() and chains multiple hooks for the same method', done => {
+      const dummyService = {
+        create(data, params, callback) {
+          callback(null, data);
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
+
+      service.after({
         create(hook, next) {
-          assert.equal(hook.type, 'after');
-
-          hook.result.some = 'thing';
-
-          next(null, hook);
-        }
-      },
-
-      create(data, params, callback) {
-        callback(null, data);
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.create({ my: 'data' }, {}, (error, data) => {
-      assert.deepEqual({ my: 'data', some: 'thing' }, data, 'Got modified data');
-      done();
-    });
-  });
-
-  it('returns errors', done => {
-    const dummyService = {
-      after: {
-        update(hook, next) {
-          next(new Error('This did not work'));
-        }
-      },
-
-      update(id, data, params, callback) {
-        callback(null, data);
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.update(1, { my: 'data' }, {}, error => {
-      assert.ok(error, 'Got an error');
-      assert.equal(error.message, 'This did not work', 'Got expected error message from hook');
-      done();
-    });
-  });
-
-  it('does not run after hook when there is an error', done => {
-    const dummyService = {
-      after: {
-        remove() {
-          assert.ok(false, 'This should never get called');
-        }
-      },
-
-      remove(id, params, callback) {
-        callback(new Error('Error removing item'));
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.remove(1, {}, error => {
-      assert.ok(error, 'Got error');
-      assert.equal(error.message, 'Error removing item', 'Got error message from service');
-      done();
-    });
-  });
-
-  it('adds .after() and chains multiple hooks for the same method', done => {
-    const dummyService = {
-      create(data, params, callback) {
-        callback(null, data);
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.after({
-      create(hook, next) {
-        hook.result.some = 'thing';
-        next();
-      }
-    });
-
-    service.after({
-      create(hook, next) {
-        hook.result.other = 'stuff';
-
-        next();
-      }
-    });
-
-    service.create({ my: 'data' }, {}, (error, data) => {
-      assert.deepEqual({
-        my: 'data',
-        some: 'thing',
-        other: 'stuff'
-      }, data, 'Got modified data');
-      done();
-    });
-  });
-
-  it('chains multiple after hooks using array syntax', done => {
-    const dummyService = {
-      create(data, params, callback) {
-        callback(null, data);
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.after({
-      create: [
-        function(hook, next) {
           hook.result.some = 'thing';
           next();
-        },
-        function(hook, next) {
+        }
+      });
+
+      service.after({
+        create(hook, next) {
           hook.result.other = 'stuff';
 
           next();
         }
-      ]
-    });
-
-    service.create({ my: 'data' }, {}, (error, data) => {
-      assert.deepEqual({
-        my: 'data',
-        some: 'thing',
-        other: 'stuff'
-      }, data, 'Got modified data');
-      done();
-    });
-  });
-
-  it('.after hooks can return a promise', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      get(id) {
-        return Promise.resolve({
-          id: id,
-          description: `You have to do ${id}`
-        });
-      },
-
-      find: function() {
-        return Promise.resolve([]);
-      }
-    });
-    const service = app.service('dummy');
-
-    service.after({
-      get(hook) {
-        return new Promise(resolve => {
-          setTimeout(function() {
-            hook.result.ran = true;
-            resolve();
-          }, 50);
-        });
-      },
-
-      find: function() {
-        return new Promise((resolve, reject) => {
-          setTimeout(function() {
-            reject(new Error('You can not see this'));
-          }, 50);
-        });
-      }
-    });
-
-    service.get('laundry', {}, (error, data) => {
-      assert.deepEqual(data, {
-        id: 'laundry',
-        description: 'You have to do laundry',
-        ran: true
       });
-      service.find({}, error => {
-        assert.equal(error.message, 'You can not see this');
+
+      service.create({ my: 'data' }, {}, (error, data) => {
+        assert.deepEqual({
+          my: 'data',
+          some: 'thing',
+          other: 'stuff'
+        }, data, 'Got modified data');
         done();
       });
     });
-  });
 
-  it('.after hooks run in the correct order (#13)', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      get(id, params, callback) {
-        callback(null, { id });
-      }
+    it('chains multiple after hooks using array syntax', done => {
+      const dummyService = {
+        create(data, params, callback) {
+          callback(null, data);
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
+
+      service.after({
+        create: [
+          function(hook, next) {
+            hook.result.some = 'thing';
+            next();
+          },
+          function(hook, next) {
+            hook.result.other = 'stuff';
+
+            next();
+          }
+        ]
+      });
+
+      service.create({ my: 'data' }, {}, (error, data) => {
+        assert.deepEqual({
+          my: 'data',
+          some: 'thing',
+          other: 'stuff'
+        }, data, 'Got modified data');
+        done();
+      });
     });
 
-    const service = app.service('dummy');
+    it('.after hooks run in the correct order (#13)', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id, params, callback) {
+          callback(null, { id });
+        }
+      });
 
-    service.after({
-      get(hook, next) {
-        hook.result.items = ['first'];
-        next();
-      }
-    });
+      const service = app.service('dummy');
 
-    service.after({
-      get: [
-        function(hook, next) {
-          hook.result.items.push('second');
+      service.after({
+        get(hook, next) {
+          hook.result.items = ['first'];
           next();
+        }
+      });
+
+      service.after({
+        get: [
+          function(hook, next) {
+            hook.result.items.push('second');
+            next();
+          },
+          function(hook, next) {
+            hook.result.items.push('third');
+            next();
+          }
+        ]
+      });
+
+      service.get(10, {}, (error, data) => {
+        assert.deepEqual(data.items, ['first', 'second', 'third']);
+        done(error);
+      });
+    });
+
+    it('after all hooks (#11)', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        after: {
+          all(hook, next) {
+            hook.result.afterAllObject = true;
+            next();
+          }
         },
+
+        get(id, params, callback) {
+          callback(null, {
+            id: id,
+            items: []
+          });
+        },
+
+        find(params, callback) {
+          callback(null, []);
+        }
+      });
+
+      const service = app.service('dummy');
+
+      service.after([
         function(hook, next) {
-          hook.result.items.push('third');
+          hook.result.afterAllMethodArray = true;
           next();
         }
-      ]
-    });
+      ]);
 
-    service.get(10, {}, (error, data) => {
-      assert.deepEqual(data.items, ['first', 'second', 'third']);
-      done(error);
-    });
-  });
-
-  it('after all hooks (#11)', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      after: {
-        all(hook, next) {
-          hook.result.afterAllObject = true;
-          next();
-        }
-      },
-
-      get(id, params, callback) {
-        callback(null, {
-          id: id,
-          items: []
-        });
-      },
-
-      find(params, callback) {
-        callback(null, []);
-      }
-    });
-
-    const service = app.service('dummy');
-
-    service.after([
-      function(hook, next) {
-        hook.result.afterAllMethodArray = true;
-        next();
-      }
-    ]);
-
-    service.find({}, (error, data) => {
-      assert.ok(data.afterAllObject);
-      assert.ok(data.afterAllMethodArray);
-
-      service.get(1, {}, (error, data) => {
+      service.find({}, (error, data) => {
         assert.ok(data.afterAllObject);
         assert.ok(data.afterAllMethodArray);
+
+        service.get(1, {}, (error, data) => {
+          assert.ok(data.afterAllObject);
+          assert.ok(data.afterAllMethodArray);
+          done();
+        });
+      });
+    });
+
+    it('after hooks have service as context and keep it in service method (#17)', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        number: 42,
+        get(id, params, callback) {
+          callback(null, {
+            id: id,
+            number: this.number
+          });
+        }
+      });
+
+      const service = app.service('dummy');
+
+      service.after({
+        get(hook, next) {
+          hook.result.test = this.number + 1;
+          next();
+        }
+      });
+
+      service.get(10, {}, (error, data) => {
+        assert.deepEqual(data, {
+          id: 10,
+          number: 42,
+          test: 43
+        });
         done();
       });
     });
-  });
 
-  it('after hooks have service as context and keep it in service method (#17)', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      number: 42,
-      get(id, params, callback) {
-        callback(null, {
-          id: id,
-          number: this.number
-        });
-      }
-    });
-
-    const service = app.service('dummy');
-
-    service.after({
-      get(hook, next) {
-        hook.result.test = this.number + 1;
-        next();
-      }
-    });
-
-    service.get(10, {}, (error, data) => {
-      assert.deepEqual(data, {
-        id: 10,
-        number: 42,
-        test: 43
-      });
-      done();
-    });
-  });
-
-  it('can not call next() multiple times', () => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      get(id, params, callback) {
-        callback(null, { id });
-      }
-    });
-
-    const service = app.service('dummy');
-
-    service.after({
-      get: [
-        function(hook, next) {
-          next();
-        },
-
-        function(hook, next) {
-          next();
-          next();
+    it('can not call next() multiple times', () => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id, params, callback) {
+          callback(null, { id });
         }
-      ]
-    });
+      });
 
-    try {
-      service.get(10);
-    } catch(e) {
-      assert.deepEqual(e.message, `next() called multiple times for hook on 'get' method`);
-    }
+      const service = app.service('dummy');
+
+      service.after({
+        get: [
+          function(hook, next) {
+            next();
+          },
+
+          function(hook, next) {
+            next();
+            next();
+          }
+        ]
+      });
+
+      try {
+        service.get(10);
+      } catch(e) {
+        assert.deepEqual(e.message, `next() called multiple times for hook on 'get' method`);
+      }
+    });
   });
 });

--- a/test/before.test.js
+++ b/test/before.test.js
@@ -1,350 +1,432 @@
 import assert from 'assert';
 import feathers from 'feathers';
 
-import hooks from '../lib/hooks';
+import hooks from '../src/hooks';
 
 describe('.before hooks', () => {
-  it('gets mixed into a service and modifies data', done => {
-    const dummyService = {
-      before: {
-        create(hook, next) {
-          assert.equal(hook.type, 'before');
+  describe('function([hook])', () => {
+    it('returning a non-hook object throws error', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id) {
+          return Promise.resolve({ id });
+        },
 
-          hook.data.modified = 'data';
-
-          Object.assign(hook.params, {
-            modified: 'params'
-          });
-
-          next(null, hook);
+        before: {
+          get() {
+            return {};
+          }
         }
-      },
+      });
+      const service = app.service('dummy');
 
-      create(data, params, callback) {
+      service.get(10).catch(e => {
+        assert.equal(e.message, 'before hook for \'get\' method returned invalid hook object');
+        done();
+      });
+    });
+
+    it('hooks in chain can be replaced', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id) {
+          return Promise.resolve({
+            id, description: `You have to do ${id}`
+          });
+        }
+      });
+
+      const service = app.service('dummy').before({
+        get: [
+          function(hook) {
+            return Object.assign({}, hook, {
+              modified: true
+            });
+          },
+          function(hook) {
+            assert.ok(hook.modified);
+          }
+        ]
+      });
+
+      service.get('laundry').then(() => done());
+    });
+
+    it('.before hooks can return a promise', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id, params) {
+          assert.ok(params.ran, 'Ran through promise hook');
+
+          return Promise.resolve({
+            id: id,
+            description: `You have to do ${id}`
+          });
+        },
+
+        remove() {
+          assert.ok(false, 'Should never get here');
+        }
+      });
+
+      const service = app.service('dummy').before({
+        get: function(hook) {
+          return new Promise(resolve => {
+            hook.params.ran = true;
+            resolve();
+          });
+        },
+
+        remove() {
+          return new Promise((resolve, reject) => {
+            reject(new Error('This did not work'));
+          });
+        }
+      });
+
+      service.get('dishes', {}, () => {
+        service.remove(10).catch(error => {
+          assert.equal(error.message, 'This did not work');
+          done();
+        });
+      });
+    });
+
+    it('.before hooks do not need to return anything', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id, params) {
+          assert.ok(params.ran, 'Ran through promise hook');
+
+          return Promise.resolve({
+            id: id,
+            description: `You have to do ${id}`
+          });
+        },
+
+        remove() {
+          assert.ok(false, 'Should never get here');
+        }
+      });
+
+      const service = app.service('dummy').before({
+        get: function(hook) {
+          hook.params.ran = true;
+        },
+
+        remove() {
+          throw new Error('This did not work');
+        }
+      });
+
+      service.get('dishes').then(() => {
+        service.remove(10).catch(error => {
+          assert.equal(error.message, 'This did not work');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('function(hook, next)', () => {
+    it('gets mixed into a service and modifies data', done => {
+      const dummyService = {
+        before: {
+          create(hook, next) {
+            assert.equal(hook.type, 'before');
+
+            hook.data.modified = 'data';
+
+            Object.assign(hook.params, {
+              modified: 'params'
+            });
+
+            next(null, hook);
+          }
+        },
+
+        create(data, params, callback) {
+          assert.deepEqual(data, {
+            some: 'thing',
+            modified: 'data'
+          }, 'Data modified');
+
+          assert.deepEqual(params, {
+            modified: 'params'
+          }, 'Params modified');
+
+          callback(null, data);
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
+
+      service.create({ some: 'thing' }, {}, (error, data) => {
+        assert.ok(!error, 'No error');
+
         assert.deepEqual(data, {
           some: 'thing',
           modified: 'data'
-        }, 'Data modified');
+        }, 'Data got modified');
 
-        assert.deepEqual(params, {
-          modified: 'params'
-        }, 'Params modified');
-
-        callback(null, data);
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.create({ some: 'thing' }, {}, (error, data) => {
-      assert.ok(!error, 'No error');
-
-      assert.deepEqual(data, {
-        some: 'thing',
-        modified: 'data'
-      }, 'Data got modified');
-
-      done();
+        done();
+      });
     });
-  });
 
-  it('passes errors', done => {
-    const dummyService = {
-      before: {
-        update(hook, next) {
-          next(new Error('You are not allowed to update'));
+    it('passes errors', done => {
+      const dummyService = {
+        before: {
+          update(hook, next) {
+            next(new Error('You are not allowed to update'));
+          }
+        },
+
+        update() {
+          assert.ok(false, 'Never should be called');
         }
-      },
+      };
 
-      update() {
-        assert.ok(false, 'Never should be called');
-      }
-    };
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
 
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.update(1, {}, {}, error => {
-      assert.ok(error, 'Got an error');
-      assert.equal(error.message, 'You are not allowed to update', 'Got error message');
-      done();
+      service.update(1, {}, {}, error => {
+        assert.ok(error, 'Got an error');
+        assert.equal(error.message, 'You are not allowed to update', 'Got error message');
+        done();
+      });
     });
-  });
 
-  it('calling back with no arguments uses the old ones', done => {
-    const dummyService = {
-      before: {
-        remove(hook, next) {
-          next();
+    it('calling back with no arguments uses the old ones', done => {
+      const dummyService = {
+        before: {
+          remove(hook, next) {
+            next();
+          }
+        },
+
+        remove(id, params, callback) {
+          assert.equal(id, 1, 'Got id');
+          assert.deepEqual(params, { my: 'param' });
+          callback();
         }
-      },
+      };
 
-      remove(id, params, callback) {
-        assert.equal(id, 1, 'Got id');
-        assert.deepEqual(params, { my: 'param' });
-        callback();
-      }
-    };
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
 
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.remove(1, { my: 'param' }, done);
-  });
-
-  it('adds .before() and chains multiple hooks for the same method', done => {
-    const dummyService = {
-      create(data, params, callback) {
-        assert.deepEqual(data, {
-          some: 'thing',
-          modified: 'second data'
-        }, 'Data modified');
-
-        assert.deepEqual(params, {
-          modified: 'params'
-        }, 'Params modified');
-
-        callback(null, data);
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.before({
-      create(hook, next) {
-        hook.params.modified = 'params';
-
-        next();
-      }
+      service.remove(1, { my: 'param' }, done);
     });
 
-    service.before({
-      create(hook, next) {
-        hook.data.modified = 'second data';
+    it('adds .before() and chains multiple hooks for the same method', done => {
+      const dummyService = {
+        create(data, params, callback) {
+          assert.deepEqual(data, {
+            some: 'thing',
+            modified: 'second data'
+          }, 'Data modified');
 
-        next();
-      }
-    });
+          assert.deepEqual(params, {
+            modified: 'params'
+          }, 'Params modified');
 
-    service.create({ some: 'thing' }, {}, error => {
-      assert.ok(!error, 'No error');
-      done();
-    });
-  });
+          callback(null, data);
+        }
+      };
 
-  it('chains multiple after hooks using array syntax', done => {
-    const dummyService = {
-      create(data, params, callback) {
-        assert.deepEqual(data, {
-          some: 'thing',
-          modified: 'second data'
-        }, 'Data modified');
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
 
-        assert.deepEqual(params, {
-          modified: 'params'
-        }, 'Params modified');
-
-        callback(null, data);
-      }
-    };
-
-    const app = feathers().configure(hooks()).use('/dummy', dummyService);
-    const service = app.service('dummy');
-
-    service.before({
-      create: [
-        function(hook, next) {
+      service.before({
+        create(hook, next) {
           hook.params.modified = 'params';
 
           next();
-        },
-        function(hook, next) {
+        }
+      });
+
+      service.before({
+        create(hook, next) {
           hook.data.modified = 'second data';
 
           next();
         }
-      ]
-    });
+      });
 
-    service.create({ some: 'thing' }, {}, error => {
-      assert.ok(!error, 'No error');
-      done();
-    });
-  });
-
-  it('.before hooks can return a promise', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      get(id, params) {
-        assert.ok(params.ran, 'Ran through promise hook');
-
-        return Promise.resolve({
-          id: id,
-          description: 'You have to do ' + id
-        });
-      },
-
-      remove() {
-        assert.ok(false, 'Should never get here');
-      }
-    });
-
-    const service = app.service('dummy').before({
-      get: function(hook) {
-        return new Promise(resolve => setTimeout(function() {
-            hook.params.ran = true;
-            resolve();
-          }, 50));
-      },
-
-      remove() {
-        return new Promise((resolve, reject) => setTimeout(function() {
-          reject(new Error('This did not work'));
-        }, 50));
-      }
-    });
-
-    service.get('dishes', {}, () => {
-      service.remove(10, {}, error => {
-        assert.equal(error.message, 'This did not work');
+      service.create({ some: 'thing' }, {}, error => {
+        assert.ok(!error, 'No error');
         done();
       });
     });
-  });
 
-  it('.before hooks run in the correct order (#13)', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      get(id, params, callback) {
-        assert.deepEqual(params.items, ['first', 'second', 'third']);
-        callback(null, {
-          id: id,
-          items: []
-        });
-      }
-    });
+    it('chains multiple before hooks using array syntax', done => {
+      const dummyService = {
+        create(data, params, callback) {
+          assert.deepEqual(data, {
+            some: 'thing',
+            modified: 'second data'
+          }, 'Data modified');
 
-    const service = app.service('dummy');
+          assert.deepEqual(params, {
+            modified: 'params'
+          }, 'Params modified');
 
-    service.before({
-      get(hook, next) {
-        hook.params.items = ['first'];
-        next();
-      }
-    });
-
-    service.before({
-      get: [
-        function(hook, next) {
-          hook.params.items.push('second');
-          next();
-        },
-        function(hook, next) {
-          hook.params.items.push('third');
-          next();
+          callback(null, data);
         }
-      ]
-    });
+      };
 
-    service.get(10, {}, done);
-  });
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
 
-  it('before all hooks (#11)', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      before: {
-        all(hook, next) {
-          hook.params.beforeAllObject = true;
-          next();
-        }
-      },
+      service.before({
+        create: [
+          function(hook, next) {
+            hook.params.modified = 'params';
 
-      get(id, params, callback) {
-        assert.ok(params.beforeAllObject);
-        assert.ok(params.beforeAllMethodArray);
-        callback(null, {
-          id: id,
-          items: []
-        });
-      },
+            next();
+          },
+          function(hook, next) {
+            hook.data.modified = 'second data';
 
-      find(params, callback) {
-        assert.ok(params.beforeAllObject);
-        assert.ok(params.beforeAllMethodArray);
-        callback(null, []);
-      }
-    });
-
-    const service = app.service('dummy');
-
-    service.before([
-      function(hook, next) {
-        hook.params.beforeAllMethodArray = true;
-        next();
-      }
-    ]);
-
-    service.find({}, () => {
-      service.get(1, {}, done);
-    });
-  });
-
-  it('before hooks have service as context and keep it in service method (#17)', done => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      number: 42,
-      get(id, params, callback) {
-        callback(null, {
-          id: id,
-          number: this.number,
-          test: params.test
-        });
-      }
-    });
-
-    const service = app.service('dummy');
-
-    service.before({
-      get(hook, next) {
-        hook.params.test = this.number + 2;
-        next();
-      }
-    });
-
-    service.get(10, {}, (error, data) => {
-      assert.deepEqual(data, {
-        id: 10,
-        number: 42,
-        test: 44
+            next();
+          }
+        ]
       });
-      done();
-    });
-  });
 
-  it('can not call next() multiple times', () => {
-    const app = feathers().configure(hooks()).use('/dummy', {
-      get(id, params, callback) {
-        callback(null, { id });
-      }
+      service.create({ some: 'thing' }, {}, error => {
+        assert.ok(!error, 'No error');
+        done();
+      });
     });
 
-    const service = app.service('dummy');
+    it('.before hooks run in the correct order (#13)', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id, params, callback) {
+          assert.deepEqual(params.items, ['first', 'second', 'third']);
+          callback(null, {
+            id: id,
+            items: []
+          });
+        }
+      });
 
-    service.before({
-      get: [
-        function(hook, next) {
-          next();
-        },
+      const service = app.service('dummy');
 
-        function(hook, next) {
-          next();
+      service.before({
+        get(hook, next) {
+          hook.params.items = ['first'];
           next();
         }
-      ]
+      });
+
+      service.before({
+        get: [
+          function(hook, next) {
+            hook.params.items.push('second');
+            next();
+          },
+          function(hook, next) {
+            hook.params.items.push('third');
+            next();
+          }
+        ]
+      });
+
+      service.get(10, {}, done);
     });
 
-    try {
-      service.get(10);
-    } catch(e) {
-      assert.deepEqual(e.message, `next() called multiple times for hook on 'get' method`);
-    }
+    it('before all hooks (#11)', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        before: {
+          all(hook, next) {
+            hook.params.beforeAllObject = true;
+            next();
+          }
+        },
+
+        get(id, params, callback) {
+          assert.ok(params.beforeAllObject);
+          assert.ok(params.beforeAllMethodArray);
+          callback(null, {
+            id: id,
+            items: []
+          });
+        },
+
+        find(params, callback) {
+          assert.ok(params.beforeAllObject);
+          assert.ok(params.beforeAllMethodArray);
+          callback(null, []);
+        }
+      });
+
+      const service = app.service('dummy');
+
+      service.before([
+        function(hook, next) {
+          hook.params.beforeAllMethodArray = true;
+          next();
+        }
+      ]);
+
+      service.find({}, () => {
+        service.get(1, {}, done);
+      });
+    });
+
+    it('before hooks have service as context and keep it in service method (#17)', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        number: 42,
+        get(id, params, callback) {
+          callback(null, {
+            id: id,
+            number: this.number,
+            test: params.test
+          });
+        }
+      });
+
+      const service = app.service('dummy');
+
+      service.before({
+        get(hook, next) {
+          hook.params.test = this.number + 2;
+          next();
+        }
+      });
+
+      service.get(10, {}, (error, data) => {
+        assert.deepEqual(data, {
+          id: 10,
+          number: 42,
+          test: 44
+        });
+        done();
+      });
+    });
+
+    it('calling next() multiple times does not do anything', done => {
+      const app = feathers().configure(hooks()).use('/dummy', {
+        get(id, params, callback) {
+          callback(null, { id });
+        }
+      });
+
+      const service = app.service('dummy');
+
+      service.before({
+        get: [
+          function(hook, next) {
+            next();
+          },
+
+          function(hook, next) {
+            next();
+            next();
+          }
+        ]
+      });
+
+      service.get(10).then(data => {
+        assert.deepEqual(data, { id: 10 });
+        done();
+      });
+    });
   });
 });

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import feathers from 'feathers';
+
+import hooks from '../src/hooks';
+
+describe('feathers-hooks', () => {
+  it('always turns service call into a promise (#28)', done => {
+    const app = feathers().configure(hooks()).use('/dummy', {
+      get(id, params, callback) {
+        callback(null, { id });
+      }
+    });
+
+    const service = app.service('dummy');
+
+    service.get(10).then(data => {
+      assert.deepEqual(data, { id: 10 });
+      done();
+    });
+  });
+
+  it('works with services that return a promise (#28)', done => {
+    const app = feathers().configure(hooks()).use('/dummy', {
+      get(id, params) {
+        return Promise.resolve({ id, user: params.user });
+      }
+    });
+
+    const service = app.service('dummy');
+
+    service.before({
+      get(hook) {
+        hook.params.user = 'David';
+      }
+    }).after({
+      get(hook) {
+        hook.result.after = true;
+      }
+    });
+
+    service.get(10).then(data => {
+      assert.deepEqual(data, { id: 10, user: 'David', after: true });
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This pull request is a larger refactoring that allows service methods that return promises and turns hooks into promise chains. They can now also be used like this:

```js
app.service('todos').before({
  create(hook) {
    if(!hook.data.text) {
      throw new Error('Text has to be provided');
    }

    hook.data.text = data.text.substring(0, 255);
  }
});
```

Closes #28