### PR TITLE
Adds the app object at hook.app.

### DIFF
--- a/src/before.js
+++ b/src/before.js
@@ -1,54 +1,58 @@
 import { hooks as utils } from 'feathers-commons';
 import { addHookMethod, processHooks } from './commons';
 
-export default function(service) {
-  if(typeof service.mixin !== 'function') {
-    return;
-  }
-
-  const methods = this.methods;
-  const old = service.before;
-  const mixin = {};
-
-  addHookMethod(service, 'before', methods);
-
-  methods.forEach(method => {
-    if(typeof service[method] !== 'function') {
+export default function(app) {
+  return function(service){
+    if(typeof service.mixin !== 'function') {
       return;
     }
 
-    mixin[method] = function() {
-      const _super = this._super.bind(this);
-      const hookObject = utils.hookObject(method, 'before', arguments);
-      const hooks = this.__beforeHooks[method];
+    const methods = this.methods;
+    const old = service.before;
+    const mixin = {};
 
-      // Run all hooks
-      let promise = processHooks.call(this, hooks, hookObject);
+    addHookMethod(service, 'before', methods);
 
-      // Then call the original method
-      return promise.then(hookObject => {
-        return new Promise((resolve, reject) => {
-          const args = utils.makeArguments(hookObject);
+    methods.forEach(method => {
+      if(typeof service[method] !== 'function') {
+        return;
+      }
 
-          // We replace the callback with resolving the promise
-          args.splice(args.length - 1, 1, (error, result) => {
-            if(error) {
-              reject(error);
-            } else {
-              hookObject.result = result;
-              resolve(hookObject);
-            }
+      mixin[method] = function() {
+        const _super = this._super.bind(this);
+        const hookObject = utils.hookObject(method, 'before', arguments);
+        const hooks = this.__beforeHooks[method];
+
+        hookObject.app = app;
+
+        // Run all hooks
+        let promise = processHooks.call(this, hooks, hookObject);
+
+        // Then call the original method
+        return promise.then(hookObject => {
+          return new Promise((resolve, reject) => {
+            const args = utils.makeArguments(hookObject);
+
+            // We replace the callback with resolving the promise
+            args.splice(args.length - 1, 1, (error, result) => {
+              if(error) {
+                reject(error);
+              } else {
+                hookObject.result = result;
+                resolve(hookObject);
+              }
+            });
+
+            _super(... args);
           });
-
-          _super(... args);
         });
-      });
-    };
-  });
+      };
+    });
 
-  service.mixin(mixin);
+    service.mixin(mixin);
 
-  if(old) {
-    service.before(old);
-  }
+    if(old) {
+      service.before(old);
+    }
+  };
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -3,7 +3,7 @@ import after from './after';
 
 export default function() {
   return function() {
-    this.mixins.push(before);
+    this.mixins.push(before(this));
     this.mixins.push(after);
   };
 }

--- a/test/after.test.js
+++ b/test/after.test.js
@@ -130,6 +130,31 @@ describe('.after hooks', () => {
       });
     });
 
+    it('also makes the app available at hook.app', done => {
+      const dummyService = {
+        after: {
+          create(hook, next) {
+            hook.result.appPresent = typeof hook.app === 'function';
+            assert.equal(hook.result.appPresent, true);
+
+            next(null, hook);
+          }
+        },
+
+        create(data, params, callback) {
+          callback(null, data);
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/dummy', dummyService);
+      const service = app.service('dummy');
+
+      service.create({ my: 'data' }, {}, (error, data) => {
+        assert.deepEqual({ my: 'data', appPresent: true }, data, 'The app was present in the hook.');
+        done();
+      });
+    });
+
     it('returns errors', done => {
       const dummyService = {
         after: {

--- a/test/before.test.js
+++ b/test/before.test.js
@@ -170,6 +170,35 @@ describe('.before hooks', () => {
       });
     });
 
+    it('contains the app object at hook.app', done => {
+      const someServiceConfig = {
+        before: {
+          create(hook, next) {
+            hook.data.appPresent = typeof hook.app === 'function';
+            assert.equal(hook.data.appPresent, true);
+            next(null, hook);
+          }
+        },
+
+        create(data, params, callback) {
+          callback(null, data);
+        }
+      };
+
+      const app = feathers().configure(hooks()).use('/some-service', someServiceConfig);
+      const someService = app.service('some-service');
+
+      someService.create({ some: 'thing' }, {}, (error, data) => {
+
+        assert.deepEqual(data, {
+          some: 'thing',
+          appPresent: true
+        }, 'App object was present');
+
+        done();
+      });
+    });
+
     it('passes errors', done => {
       const dummyService = {
         before: {


### PR DESCRIPTION
I think this is the most elegant place to add the app object so that it's always available in hooks, even on internal requests (which don't pass through one of the providers).

The next issue that will surface is probably circular requests where service A requests data from B, B from C, and C from A.