### PR TITLE
Params provider

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,6 +23,8 @@
         "describe": true,
         "before": true,
         "after": true,
+        "beforeEach": true,
+        "afterEach": true,
         "exports": true
     }
 }

--- a/src/bundled.js
+++ b/src/bundled.js
@@ -39,7 +39,7 @@ export function remove(... fields) {
     }
   };
   const callback = typeof fields[fields.length - 1] === 'function' ?
-    fields.pop() : () => true;
+    fields.pop() : (hook) => !!hook.params.provider;
 
   return function(hook) {
     const result = hook.type === 'before' ? hook.data : hook.result;

--- a/test/bundled.test.js
+++ b/test/bundled.test.js
@@ -206,7 +206,6 @@ describe('Bundled feathers hooks', () => {
           done();
         }).catch(done);
       });
->>>>>>> only run remove hook if params.provider is set
     });
   });
 

--- a/test/bundled.test.js
+++ b/test/bundled.test.js
@@ -4,6 +4,12 @@ import rest from 'feathers-rest';
 import memory from 'feathers-memory';
 import hooks from '../src/hooks';
 
+const addProvider = function(){
+  return function(hook){
+    hook.params.provider = 'rest';
+  };
+};
+
 const app = feathers()
   .configure(rest())
   .configure(hooks())
@@ -11,15 +17,21 @@ const app = feathers()
 
 const service = app.service('/todos');
 
-service.create([
-  {id: 1, name: 'Marshall', title: 'Old Man', admin: true},
-  {id: 2, name: 'David', title: 'Genius', admin: true},
-  {id: 3, name: 'Eric', title: 'Badass', admin: true}
-]);
-
 describe('Bundled feathers hooks', () => {
+  beforeEach(done => {
+    service.create([
+      {id: 1, name: 'Marshall', title: 'Old Man', admin: true},
+      {id: 2, name: 'David', title: 'Genius', admin: true},
+      {id: 3, name: 'Eric', title: 'Badass', admin: true}
+    ]).then(() => done());
+  });
+
+  afterEach(done => {
+    service.remove(null).then(() => done());
+  });
+
   describe('lowerCase', () => {
-    it('Transform to lower case fields from objects in arrays', done => {
+    it('transforms to lower case fields from objects in arrays', done => {
       service.after({
         find: hooks.lowerCase('name')
       });
@@ -34,7 +46,7 @@ describe('Bundled feathers hooks', () => {
       }).catch(done);
     });
 
-    it('Transform to lower case fields from single objects', done => {
+    it('transforms to lower case fields from single objects', done => {
       service.after({
         get: hooks.lowerCase('name')
       });
@@ -47,7 +59,7 @@ describe('Bundled feathers hooks', () => {
       }).catch(done);
     });
 
-    it('Transform to lower case fields from data if it is a before hook', done => {
+    it('transforms to lower case fields from data if it is a before hook', done => {
       service.before({
         create: hooks.lowerCase('name')
       });
@@ -66,100 +78,135 @@ describe('Bundled feathers hooks', () => {
   });
 
   describe('remove', () => {
-    it('Removes fields from objects in arrays', done => {
-      service.after({
-        find: hooks.remove('title')
+    describe('with params.provider set', () => {
+      before(() => {
+        service.before({
+          find: addProvider(),
+          get: addProvider(),
+          create: addProvider()
+        });
       });
 
-      service.find().then(data => {
-        assert.equal(data[0].title, undefined);
-        assert.equal(data[1].title, undefined);
-        assert.equal(data[2].title, undefined);
-        // Remove the hook we just added
-        service.__afterHooks.find.pop();
-        done();
-      }).catch(done);
-    });
-
-    it('Removes multiple fields from single objects', done => {
-      service.after({
-        get: hooks.remove('admin', 'title')
-      });
-
-      service.get(1).then(data => {
-        assert.equal(data.admin, undefined);
-        assert.equal(data.title, undefined);
-        // Remove the hook we just added
-        service.__afterHooks.get.pop();
-        done();
-      }).catch(done);
-    });
-
-    it('removes fields from data if it is a before hook', done => {
-      service.before({
-        create: hooks.remove('_id')
-      });
-
-      service.create({
-        _id: 10,
-        name: 'David'
-      }).then(data => {
-        assert.equal(data.name, 'David');
-        assert.equal(data._id, undefined);
-        // Remove the hook we just added
+      after(() => {
+        // remove our before hooks
+        service.__beforeHooks.find.pop();
+        service.__beforeHooks.get.pop();
         service.__beforeHooks.create.pop();
-        done();
-      }).catch(done);
-    });
-
-    it('removes field with a callback', done => {
-      const original = {
-        id: 10,
-        age: 12,
-        test: 'David'
-      };
-
-      service.before({
-        create: hooks.remove('test', hook => hook.params.remove)
       });
 
-      service.create(original).then(data => {
-        assert.deepEqual(data, original);
-        original.id = 11;
-
-        return service.create(original, { remove: true });
-      }).then(data => {
-        assert.deepEqual(data, { age: 12, id: 11 });
-        // Remove the hook we just added
-        service.__beforeHooks.create.pop();
-        done();
-      }).catch(done);
-    });
-
-    it('removes field with callback that returns a Promise', done => {
-      const original = {
-        id: 23,
-        age: 12,
-        test: 'David'
-      };
-
-      service.before({
-        create: hooks.remove('test', hook => new Promise(resolve => {
-          setTimeout(() => resolve(hook.params.remove), 20);
-        }))
+      it('Removes fields from objects in arrays', done => {
+        service.after({
+          find: hooks.remove('title')
+        });
+        
+        service.find().then(data => {
+          assert.equal(data[0].title, undefined);
+          assert.equal(data[1].title, undefined);
+          assert.equal(data[2].title, undefined);
+          // Remove the hook we just added
+          service.__afterHooks.find.pop();
+          done();
+        }).catch(done);
       });
 
-      service.create(original).then(data => {
-        assert.deepEqual(data, original);
-        original.id = 24;
+      it('Removes multiple fields from single objects', done => {
+        service.after({
+          get: hooks.remove('admin', 'title')
+        });
+        
+        service.get(1).then(data => {
+          assert.equal(data.admin, undefined);
+          assert.equal(data.title, undefined);
+          // Remove the hook we just added
+          service.__afterHooks.get.pop();
+          done();
+        }).catch(done);
+      });
+      
+      it('removes fields from data if it is a before hook', done => {
+        service.before({
+          create: hooks.remove('_id')
+        });
+        
+        service.create({
+          _id: 10,
+          name: 'David'
+        }).then(data => {
+          assert.equal(data.name, 'David');
+          assert.equal(data._id, undefined);
+          // Remove the hook we just added
+          service.__beforeHooks.create.pop();
+          done();
+        }).catch(done);
+      });
+      
+      it('removes field with a callback', done => {
+        const original = {
+          id: 10,
+          age: 12,
+          test: 'David'
+        };
+        
+        service.before({
+          create: hooks.remove('test', hook => hook.params.remove)
+        });
+        
+        service.create(original).then(data => {
+          assert.deepEqual(data, original);
+          original.id = 11;
+          
+          return service.create(original, { remove: true });
+        }).then(data => {
+          assert.deepEqual(data, { age: 12, id: 11 });
+          // Remove the hook we just added
+          service.__beforeHooks.create.pop();
+          done();
+        }).catch(done);
+      });
+      
+      it('removes field with callback that returns a Promise', done => {
+        const original = {
+          id: 23,
+          age: 12,
+          test: 'David'
+        };
+        
+        service.before({
+          create: hooks.remove('test', hook => new Promise(resolve => {
+            setTimeout(() => resolve(hook.params.remove), 20);
+          }))
+        });
+        
+        service.create(original).then(data => {
+          assert.deepEqual(data, original);
+          original.id = 24;
+          
+          return service.create(original, { remove: true });
+        }).then(data => {
+          assert.deepEqual(data, { age: 12, id: 24 });
+          // Remove the hook we just added
+          service.__beforeHooks.create.pop();
+          done();
+        }).catch(done);
+      });
+    });
 
-        return service.create(original, { remove: true });
-      }).then(data => {
-        assert.deepEqual(data, { age: 12, id: 24 });
-        // Remove the hook we just added
-        service.__beforeHooks.create.pop();
-        done();
-      }).catch(done);
+    describe('without params.provider set', () => {
+      it('does not remove fields', done => {
+        service.after({
+          find: hooks.remove('title')
+        });
+        
+        service.find().then(data => {
+          assert.equal(data[0].title, 'Old Man');
+          assert.equal(data[1].title, 'Genius');
+          assert.equal(data[2].title, 'Badass');
+          // Remove the hook we just added
+          service.__afterHooks.find.pop();
+          done();
+        }).catch(done);
+      });
+>>>>>>> only run remove hook if params.provider is set
     });
   });
 


### PR DESCRIPTION
Making it so that remove hook only runs when `params.provider` is set (ie. a call over sockets or rest happened).