### PR TITLE
Add "pluck" bundled hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "compile": "rm -rf lib/ && babel -d lib/ src/",
+    "compile": "rimraf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
     "mocha": "mocha test/ --compilers js:babel-core/register",
@@ -54,6 +54,7 @@
     "feathers-memory": "^0.6.1",
     "feathers-rest": "^1.2.2",
     "jshint": "^2.8.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "rimraf": "^2.5.2"
   }
 }

--- a/src/bundled.js
+++ b/src/bundled.js
@@ -38,6 +38,7 @@ export function remove(... fields) {
       delete data[field];
     }
   };
+  
   const callback = typeof fields[fields.length - 1] === 'function' ?
     fields.pop() : (hook) => !!hook.params.provider;
 
@@ -50,6 +51,40 @@ export function remove(... fields) {
           (result.data || result).forEach(removeFields);
         } else {
           removeFields(result);
+        }
+      }
+      return hook;
+    };
+
+    const check = callback(hook);
+
+    return check && typeof check.then === 'function' ?
+      check.then(next) : next(check);
+  };
+}
+
+export function pluck(... fields) {
+  const pluckFields = data => {
+    for(let key of Object.keys(data)) {
+      if(fields.indexOf(key) === -1) {
+        data[key] = undefined;
+        delete data[key];
+      }
+    }
+  };
+  
+  const callback = typeof fields[fields.length - 1] === 'function' ?
+    fields.pop() : (hook) => !!hook.params.provider;
+
+  return function(hook) {
+    const result = hook.type === 'before' ? hook.data : hook.result;
+    const next = condition => {
+      if(result && condition) {
+        if(hook.method === 'find' || Array.isArray(result)) {
+          // data.data if the find method is paginated
+          (result.data || result).forEach(pluckFields);
+        } else {
+          pluckFields(result);
         }
       }
       return hook;

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -96,6 +96,7 @@ function configure() {
 
 configure.lowerCase = hooks.lowerCase;
 configure.remove = hooks.remove;
+configure.pluck = hooks.pluck;
 configure.disable = hooks.disable;
 
 export default configure;


### PR DESCRIPTION
`.pluck` is like `.remove` but it includes only the fields it's given, rather than excluding them. Fixes #50. Also including a quick fix for `npm compile` on Windows.