### PR TITLE
Query bundled hooks

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -31,6 +31,70 @@ export function lowerCase(... fields) {
   };
 }
 
+export function removeQuery(... fields) {
+  const removeQueries = data => {
+    for(let field of fields) {
+      data[field] = undefined;
+      delete data[field];
+    }
+  };
+  
+  const callback = typeof fields[fields.length - 1] === 'function' ?
+    fields.pop() : () => true;
+
+  return function(hook) {
+    if (hook.type === 'after') {
+      throw new errors.GeneralError(`Provider '${hook.params.provider}' can not remove query params on after hook.`);
+    }
+    const result = hook.params.query; 
+    const next = condition => {
+      if(result && condition) {
+        removeQueries(result);
+      }
+      return hook;
+    };
+
+    const check = callback(hook);
+
+    return check && typeof check.then === 'function' ?
+      check.then(next) : next(check);
+  };
+}
+
+export function pluckQuery(... fields) {
+  const pluckQueries = data => {
+    // admin, name
+    for(let key of Object.keys(data)) {
+      if(fields.indexOf(key) === -1) {
+        console.log(key);
+        data[key] = undefined;
+        delete data[key];
+      }
+    }
+  };
+  
+  const callback = typeof fields[fields.length - 1] === 'function' ?
+    fields.pop() : () => true;
+
+  return function(hook) {
+    if (hook.type === 'after') {
+      throw new errors.GeneralError(`Provider '${hook.params.provider}' can not pluck query params on after hook.`);
+    }
+    const result = hook.params.query;
+    const next = condition => {
+      if(result && condition) {
+        pluckQueries(result);
+      }
+      return hook;
+    };
+
+    const check = callback(hook);
+
+    return check && typeof check.then === 'function' ?
+      check.then(next) : next(check);
+  };
+}
+
 export function remove(... fields) {
   const removeFields = data => {
     for(let field of fields) {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -94,6 +94,8 @@ function configure() {
   };
 }
 
+configure.removeQuery = hooks.removeQuery;
+configure.pluckQuery = hooks.pluckQuery;
 configure.lowerCase = hooks.lowerCase;
 configure.remove = hooks.remove;
 configure.disable = hooks.disable;

--- a/test/bundled.test.js
+++ b/test/bundled.test.js
@@ -209,6 +209,70 @@ describe('Bundled feathers hooks', () => {
     });
   });
 
+  describe('pluckQuery', () => {
+    it('Plucks fields from query', done => {
+      service.before({
+        find: hooks.pluckQuery('name', 'id')
+      });
+
+      service.find({query: {admin: false, name: 'David'}}).then(data => {
+        assert.equal(data.length, 1);
+        assert.deepEqual(data[0], {
+          id: 2,
+          name: 'David',
+          title: 'Genius',
+          admin: true
+        });
+        // Remove the hook we just added
+        service.__beforeHooks.find.pop();
+        done();
+      }).catch(done);
+    });
+
+    it('Throws error if placed in after', done => {
+      service.after({
+        find: hooks.pluckQuery('admin', 'title')
+      });
+
+      service.find({query: {admin: true, name: 'David'}}).then(done).catch(e => {
+        assert.equal(e.name, 'GeneralError');
+
+        // Remove the hook we just added
+        service.__afterHooks.find.pop();
+        done();
+      });
+    });
+  });
+  
+  describe('removeQuery', () => {
+    it('Removes fields from query', done => {
+      service.before({
+        find: hooks.removeQuery('name')
+      });
+     
+      service.find({query: {admin: true, name: 'David'}}).then(data => {
+        assert.equal(data.length, 3);
+        // Remove the hook we just added
+        service.__beforeHooks.find.pop();
+        done();
+      }).catch(done);
+    });
+
+    it('Throws error if placed in after', done => {
+      service.after({
+        find: hooks.removeQuery('admin', 'title')
+      });
+
+      service.find({query: {admin: true, name: 'David'}}).then(done).catch(e => {
+        assert.equal(e.name, 'GeneralError');
+
+        // Remove the hook we just added
+        service.__afterHooks.find.pop();        
+        done();
+      });
+    });
+  });
+
   describe('disable', () => {
     it('disables completely', done => {
       service.before({


### PR DESCRIPTION
These bundled hooks serve to remove and pluck query params.

Picture a situation in which you have user resources with passwords
```
[
  {
    username: "foo",
    password: "password"
  }
]
```
You shouldn't be able to have a `password: "password"` query parameter - it would be a security hole. You can either `.pluck('username')` to only permit querying based on username, or `.remove('password')` to permit querying on anything other than password.

Not sure if the tests on the two of these are sufficient or not. Let me know.