### PR TITLE
Adding functionality and tests for the populate hook

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -94,3 +94,66 @@ export function disable(realm, ... args) {
     };
   }
 }
+
+export function populate(target, options) {
+  options = Object.assign({}, options);
+
+  if (!options.service) {
+    throw new Error('You need to provide a service');
+  }
+
+  const field = options.field || target;
+
+  return function(hook) {
+    function populate(item) {
+      if(!item[field]) {
+        return Promise.resolve(item);
+      }
+
+      // Find by the field value by default or a custom query
+      const id = item[field];
+
+      // If it's a mongoose model then
+      if (typeof item.toObject === 'function') {
+        item = item.toObject(options);
+      }
+      // If it's a Sequelize model
+      else if (typeof item.toJSON === 'function') {
+        item = item.toJSON(options);
+      }
+
+      return hook.app.service(options.service)
+        .get(id, hook.params)
+        .then(relatedItem => {
+          if(relatedItem) {
+            item[target] = relatedItem;
+          }
+
+          return item;
+        }).catch(() => item);
+    }
+
+    if(hook.type === 'after') {
+      const isPaginated = (hook.method === 'find' && hook.result.data);
+      const data = isPaginated ? hook.result.data : hook.result;
+
+      if (Array.isArray(data)) {
+        return Promise.all(data.map(populate)).then(results => {
+          if(isPaginated) {
+            hook.result.data = results;
+          } else {
+            hook.result = results;
+          }
+
+          return hook;
+        });
+      }
+
+      // Handle single objects.
+      return populate(hook.result).then(item => {
+        hook.result = item;
+        return hook;
+      });
+    }
+  };
+}

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -12,7 +12,7 @@ function hookMixin(service){
   if(typeof service.mixin !== 'function') {
     return;
   }
-  
+
   const app = this;
   const methods = app.methods;
   const oldBefore = service.before;
@@ -34,7 +34,7 @@ function hookMixin(service){
       const hookObject = utils.hookObject(method, 'before', arguments);
 
       hookObject.app = app;
-      
+
       // Process all before hooks
       return processHooks.call(this, this.__beforeHooks[method], hookObject)
         // Use the hook object to call the original method
@@ -42,10 +42,10 @@ function hookMixin(service){
           if(typeof hookObject.result !== 'undefined') {
             return Promise.resolve(hookObject);
           }
-          
+
           return new Promise((resolve, reject) => {
             const args = utils.makeArguments(hookObject);
-            // The method may not be normalized yet so we have to handle both 
+            // The method may not be normalized yet so we have to handle both
             // ways, either by callback or by Promise
             const callback = function(error, result) {
               if(error) {
@@ -55,12 +55,12 @@ function hookMixin(service){
                 resolve(hookObject);
               }
             };
-            
+
             // We replace the callback with resolving the promise
             args.splice(args.length - 1, 1, callback);
 
             const result = _super(... args);
-            
+
             if(isPromise(result)) {
               result.then(data => callback(null, data), callback);
             }
@@ -81,13 +81,13 @@ function hookMixin(service){
   if(oldBefore) {
     service.before(oldBefore);
   }
-  
+
   // After hooks that were registered in the service
   if(oldAfter) {
     service.after(oldAfter);
   }
 }
-    
+
 function configure() {
   return function() {
     this.mixins.unshift(hookMixin);
@@ -97,5 +97,6 @@ function configure() {
 configure.lowerCase = hooks.lowerCase;
 configure.remove = hooks.remove;
 configure.disable = hooks.disable;
+configure.populate = hooks.populate;
 
 export default configure;

--- a/test/bundled.test.js
+++ b/test/bundled.test.js
@@ -98,7 +98,7 @@ describe('Bundled feathers hooks', () => {
         service.after({
           find: hooks.remove('title')
         });
-        
+
         service.find().then(data => {
           assert.equal(data[0].title, undefined);
           assert.equal(data[1].title, undefined);
@@ -113,7 +113,7 @@ describe('Bundled feathers hooks', () => {
         service.after({
           get: hooks.remove('admin', 'title')
         });
-        
+
         service.get(1).then(data => {
           assert.equal(data.admin, undefined);
           assert.equal(data.title, undefined);
@@ -122,12 +122,12 @@ describe('Bundled feathers hooks', () => {
           done();
         }).catch(done);
       });
-      
+
       it('removes fields from data if it is a before hook', done => {
         service.before({
           create: hooks.remove('_id')
         });
-        
+
         service.create({
           _id: 10,
           name: 'David'
@@ -139,22 +139,22 @@ describe('Bundled feathers hooks', () => {
           done();
         }).catch(done);
       });
-      
+
       it('removes field with a callback', done => {
         const original = {
           id: 10,
           age: 12,
           test: 'David'
         };
-        
+
         service.before({
           create: hooks.remove('test', hook => hook.params.remove)
         });
-        
+
         service.create(original).then(data => {
           assert.deepEqual(data, original);
           original.id = 11;
-          
+
           return service.create(original, { remove: true });
         }).then(data => {
           assert.deepEqual(data, { age: 12, id: 11 });
@@ -163,24 +163,24 @@ describe('Bundled feathers hooks', () => {
           done();
         }).catch(done);
       });
-      
+
       it('removes field with callback that returns a Promise', done => {
         const original = {
           id: 23,
           age: 12,
           test: 'David'
         };
-        
+
         service.before({
           create: hooks.remove('test', hook => new Promise(resolve => {
             setTimeout(() => resolve(hook.params.remove), 20);
           }))
         });
-        
+
         service.create(original).then(data => {
           assert.deepEqual(data, original);
           original.id = 24;
-          
+
           return service.create(original, { remove: true });
         }).then(data => {
           assert.deepEqual(data, { age: 12, id: 24 });
@@ -196,7 +196,7 @@ describe('Bundled feathers hooks', () => {
         service.after({
           find: hooks.remove('title')
         });
-        
+
         service.find().then(data => {
           assert.equal(data[0].title, 'Old Man');
           assert.equal(data[1].title, 'Genius');
@@ -300,6 +300,66 @@ describe('Bundled feathers hooks', () => {
         assert.equal(e.message, 'Not allowed!');
         // Remove the hook we just tested
         service.__beforeHooks.remove.pop();
+        done();
+      }).catch(done);
+    });
+  });
+
+  describe('populate', () => {
+    let app;
+
+    before(() => {
+      app = feathers()
+        .configure(rest())
+        .configure(hooks())
+        .use('/todos', memory())
+        .use('/users', {
+          get(id) {
+            return Promise.resolve({
+              id, name: `user ${id}`
+            });
+          }
+        });
+    });
+
+    it('populates the same field', done => {
+      app.service('todos').after({
+        create: hooks.populate('user', { service: 'users' })
+      });
+
+      app.service('todos').create({
+        text: 'A todo',
+        user: 10
+      }).then(todo => {
+        assert.deepEqual(todo, {
+          text: 'A todo',
+          user: { id: 10, name: 'user 10' },
+          id: 0
+        });
+        service.__afterHooks.create.pop();
+        done();
+      }).catch(done);
+    });
+
+    it('populates a different field', done => {
+      app.service('todos').after({
+        create: hooks.populate('user', {
+          service: 'users',
+          field: 'userId'
+        })
+      });
+
+      app.service('todos').create({
+        text: 'A todo',
+        userId: 10
+      }).then(todo => {
+        assert.deepEqual(todo, {
+          text: 'A todo',
+          userId: 10,
+          user: { id: 10, name: 'user 10' },
+          id: 1
+        });
+        service.__afterHooks.create.pop();
         done();
       }).catch(done);
     });


### PR DESCRIPTION
It looks like this:

## Re-populating the same field:

```js
app.service('todos').after({
  create: hooks.populate('user', { service: 'users' })
});

app.service('todos').create({
  text: 'A todo',
  user: 10
}).then(todo => {
  assert.deepEqual(todo, {
    text: 'A todo',
    user: { id: 10, name: 'user 10' },
    id: 0
  });
  done();
}).catch(done);
```

## Populating a different field

```js
app.service('todos').after({
  create: hooks.populate('user', {
    service: 'users',
    field: 'userId'
  })
});

app.service('todos').create({
  text: 'A todo',
  userId: 10
}).then(todo => {
  assert.deepEqual(todo, {
    text: 'A todo',
    userId: 10,
    user: { id: 10, name: 'user 10' },
    id: 1
  });
  done();
}).catch(done);
```

Closes #17