### PR TITLE
Do not throw an error when a field that is supposed to be lowercased is undefined

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -3,8 +3,13 @@ const errors = require('feathers-errors').errors;
 export function lowerCase(... fields) {
   const lowerCaseFields = data => {
     for(let field of fields) {
-      data[field] = typeof data[field] === 'string' ?
-        data[field].toLowerCase() : data[field]
+      if(data[field]) {
+        if(typeof data[field] !== 'string') {
+          throw new errors.BadRequest('Expected string');
+        } else {
+          data[field] = data[field].toLowerCase();
+        }
+      }
     }
   };
 

--- a/src/bundled.js
+++ b/src/bundled.js
@@ -3,7 +3,8 @@ const errors = require('feathers-errors').errors;
 export function lowerCase(... fields) {
   const lowerCaseFields = data => {
     for(let field of fields) {
-      data[field] = data[field].toLowerCase();
+      data[field] = typeof data[field] === 'string' ?
+        data[field].toLowerCase() : data[field]
     }
   };
 
@@ -102,7 +103,7 @@ export function remove(... fields) {
       delete data[field];
     }
   };
-  
+
   const callback = typeof fields[fields.length - 1] === 'function' ?
     fields.pop() : (hook) => !!hook.params.provider;
 
@@ -143,7 +144,7 @@ export function pluck(... fields) {
       }
     }
   };
-  
+
   const callback = typeof fields[fields.length - 1] === 'function' ?
     fields.pop() : (hook) => !!hook.params.provider;
 


### PR DESCRIPTION
This solves an issue when you have a hook:
```javascript
all: [
  hooks.lowerCase('email', 'username')
]
```
and you do not receive data that are supposed to be lowercased. Currently it throws `TypeError: Cannot call method 'toLowerCase' of undefined`.