### PR TITLE
Handle array population

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -44,7 +44,7 @@ export function removeQuery(... fields) {
       delete data[field];
     }
   };
-  
+
   const callback = typeof fields[fields.length - 1] === 'function' ?
     fields.pop() : () => true;
 
@@ -52,7 +52,7 @@ export function removeQuery(... fields) {
     if (hook.type === 'after') {
       throw new errors.GeneralError(`Provider '${hook.params.provider}' can not remove query params on after hook.`);
     }
-    const result = hook.params.query; 
+    const result = hook.params.query;
     const next = condition => {
       if(result && condition) {
         removeQueries(result);
@@ -76,7 +76,7 @@ export function pluckQuery(... fields) {
       }
     }
   };
-  
+
   const callback = typeof fields[fields.length - 1] === 'function' ?
     fields.pop() : () => true;
 
@@ -231,14 +231,12 @@ export function populate(target, options) {
       else if (typeof item.toJSON === 'function') {
         item = item.toJSON(options);
       }
-
-      return hook.app.service(options.service)
-        .get(id, hook.params)
-        .then(relatedItem => {
+      // If the relationship is an array of ids, fetch and resolve an object for each, otherwise just fetch the object.
+      const promise = Array.isArray(id) ? Promise.all(id.map(objectID => hook.app.service(options.service).get(objectID, hook.params))) : hook.app.service(options.service).get(id, hook.params);
+      return promise.then(relatedItem => {
           if(relatedItem) {
             item[target] = relatedItem;
           }
-
           return item;
         }).catch(() => item);
     }

--- a/test/bundled.test.js
+++ b/test/bundled.test.js
@@ -435,13 +435,13 @@ describe('Bundled feathers hooks', () => {
       });
     });
   });
-  
+
   describe('removeQuery', () => {
     it('Removes fields from query', done => {
       service.before({
         find: hooks.removeQuery('name')
       });
-     
+
       service.find({query: {admin: true, name: 'David'}}).then(data => {
         assert.equal(data.length, 3);
         // Remove the hook we just added
@@ -459,7 +459,7 @@ describe('Bundled feathers hooks', () => {
         assert.equal(e.name, 'GeneralError');
 
         // Remove the hook we just added
-        service.__afterHooks.find.pop();        
+        service.__afterHooks.find.pop();
         done();
       });
     });
@@ -575,6 +575,14 @@ describe('Bundled feathers hooks', () => {
               id, name: `user ${id}`
             });
           }
+        })
+        // using groups service to test array population
+        .use('/groups', {
+          get(id) {
+            return Promise.resolve({
+              id, name: `group ${id}`
+            });
+          }
         });
     });
 
@@ -617,6 +625,28 @@ describe('Bundled feathers hooks', () => {
         });
         service.__afterHooks.create.pop();
         done();
+      }).catch(done);
+    });
+
+    it('populates an array', done => {
+      app.service('todos').after({
+        create: hooks.populate('groups', {
+          service: 'groups'
+        })
+      });
+
+      app.service('todos').create({
+        'text': 'A todo',
+        groups: [12, 13]
+      })
+      .then(todo => {
+          assert.deepEqual(todo, {
+            text: 'A todo',
+            groups: [ { id: 12, name: 'group 12'}, { id: 13, name: 'group 13' }],
+            id: 2
+          });
+          service.__afterHooks.create.pop();
+          done();
       }).catch(done);
     });
   });


### PR DESCRIPTION
This fixes #74 where relationships that were arrays of identifiers were being passed to `service.get` as an id instead of mapping over each id.