### PR TITLE
Remove query in populate

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -231,14 +231,16 @@ export function populate(target, options) {
       else if (typeof item.toJSON === 'function') {
         item = item.toJSON(options);
       }
+      // Remove any query from params as it's not related
+      const params = Object.assign({}, params, { query: undefined });
       // If the relationship is an array of ids, fetch and resolve an object for each, otherwise just fetch the object.
-      const promise = Array.isArray(id) ? Promise.all(id.map(objectID => hook.app.service(options.service).get(objectID, hook.params))) : hook.app.service(options.service).get(id, hook.params);
+      const promise = Array.isArray(id) ? Promise.all(id.map(objectID => hook.app.service(options.service).get(objectID, params))) : hook.app.service(options.service).get(id, params);
       return promise.then(relatedItem => {
           if(relatedItem) {
             item[target] = relatedItem;
           }
           return item;
-        }).catch(() => item);
+        });
     }
 
     if(hook.type === 'after') {


### PR DESCRIPTION
Currently if you use populate and call with a query (for example `.find({query: {something: true}})`, the query is kept for the populate request to .get, which can cause side effects in some drivers (knex) making the .get be effectively `{id: item.id, something: true}` (which can return nothing when it should return something). This removes the query from the .get params

Also included a fix for #80 as it helped with the test