### PR TITLE
Add ability to delete deeply nested attributes in bundled hooks

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -100,7 +100,7 @@ export function pluckQuery(... fields) {
 }
 
 function containsField(obj, find) {
-    var args = find.split(".")
+    var args = find.split('.');
 
   for (var i = 0; i < args.length; i++) {
     if (!obj || !obj.hasOwnProperty(args[i])) {
@@ -112,13 +112,13 @@ function containsField(obj, find) {
 }
 
 function removeField(obj, find) {
-    var args = find.split(".")
+    var args = find.split('.');
 
   for (var i = 0; i < args.length; i++) {
     if (!obj || !obj.hasOwnProperty(args[i])) {
       return false;
     }
-    if(i == (args.length - 1)) {
+    if(i === (args.length - 1)) {
         obj[args[i]] = undefined;
         delete obj[args[i]];
         return true;
@@ -131,7 +131,7 @@ export function remove(... fields) {
   const removeFields = data => {
     for(let field of fields) {
       if(containsField(data, field)) {
-          removeField(data, field)
+          removeField(data, field);
       }
     }
   };

--- a/src/bundled.js
+++ b/src/bundled.js
@@ -99,11 +99,40 @@ export function pluckQuery(... fields) {
   };
 }
 
+function containsField(obj, find) {
+    var args = find.split(".")
+
+  for (var i = 0; i < args.length; i++) {
+    if (!obj || !obj.hasOwnProperty(args[i])) {
+      return false;
+    }
+    obj = obj[args[i]];
+  }
+  return true;
+}
+
+function removeField(obj, find) {
+    var args = find.split(".")
+
+  for (var i = 0; i < args.length; i++) {
+    if (!obj || !obj.hasOwnProperty(args[i])) {
+      return false;
+    }
+    if(i == (args.length - 1)) {
+        obj[args[i]] = undefined;
+        delete obj[args[i]];
+        return true;
+    }
+    obj = obj[args[i]];
+  }
+}
+
 export function remove(... fields) {
   const removeFields = data => {
     for(let field of fields) {
-      data[field] = undefined;
-      delete data[field];
+      if(containsField(data, field)) {
+          removeField(data, field)
+      }
     }
   };
 

--- a/test/bundled.test.js
+++ b/test/bundled.test.js
@@ -21,9 +21,9 @@ const service = app.service('/todos');
 describe('Bundled feathers hooks', () => {
   beforeEach(done => {
     service.create([
-      {id: 1, name: 'Marshall', title: 'Old Man', admin: true},
-      {id: 2, name: 'David', title: 'Genius', admin: true},
-      {id: 3, name: 'Eric', title: 'Badass', admin: true}
+      {id: 1, name: 'Marshall', title: 'Old Man', admin: true, updatedBy : { email : 'admin@feathersjs.com', roles : ['admin'] } },
+      {id: 2, name: 'David', title: 'Genius', admin: true, updatedBy : { email : 'admin@feathersjs.com', roles : ['admin'] } },
+      {id: 3, name: 'Eric', title: 'Badass', admin: true, updatedBy : { email : 'admin@feathersjs.com', roles : ['admin'] } },
     ]).then(() => done());
   });
 
@@ -243,6 +243,23 @@ describe('Bundled feathers hooks', () => {
           done();
         }).catch(done);
       });
+
+      it('Removes nested fields from result.data object', done => {
+        service.after({
+          get: [
+            hooks.remove('updatedBy.roles')
+          ]
+        });
+
+        service.get(1).then(result => {
+          assert.equal(result.data.updatedBy.roles, undefined);
+          assert.equal(result.data.updatedBy.email, 'admin@feathersjs.com');
+          // Remove the hooks we just added
+          service.__afterHooks.find.pop();
+          service.__afterHooks.find.pop();
+          done();
+        }).catch(done);
+      });
     });
 
     describe('without params.provider set', () => {
@@ -413,7 +430,8 @@ describe('Bundled feathers hooks', () => {
           id: 2,
           name: 'David',
           title: 'Genius',
-          admin: true
+          admin: true,
+          updatedBy : { email : 'admin@feathersjs.com', roles : ['admin']}
         });
         // Remove the hook we just added
         service.__beforeHooks.find.pop();


### PR DESCRIPTION
Issue #79 asked for the ability to delete deeply nested attributes in a bundled hook like:
```js
hooks.remove("user.password")
```

I added functionality which checks if the object has the field.
And also a separate function to remove the field

I needed this for myself so I thought I could share and also get a review on my code