### PR TITLE
onError hooks functionality

### DIFF
--- a/src/commons.js
+++ b/src/commons.js
@@ -3,7 +3,7 @@ import { hooks as utils } from 'feathers-commons';
 export function isHookObject(hookObject) {
   return typeof hookObject === 'object' &&
     typeof hookObject.method === 'string' &&
-    (hookObject.type === 'before' || hookObject.type === 'after');
+    typeof hookObject.type === 'string';
 }
 
 export function processHooks(hooks, initialHookObject) {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -82,6 +82,7 @@ function hookMixin(service) {
         .then(hookObject => hookObject.result)
         .catch(error => {
           const errorHook = Object.assign({}, error.hook || hookObject, {
+            type: 'onError',
             error
           });
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -83,6 +83,7 @@ function hookMixin(service) {
         .catch(error => {
           const errorHook = Object.assign({}, error.hook || hookObject, {
             type: 'onError',
+            original: error.hook,
             error
           });
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -8,15 +8,18 @@ function isPromise(result) {
     typeof result.then === 'function';
 }
 
-function hookMixin(service){
+function hookMixin(service) {
   if(typeof service.mixin !== 'function') {
     return;
   }
 
   const app = this;
   const methods = app.methods;
-  const oldBefore = service.before;
-  const oldAfter = service.after;
+  const old = {
+    before: service.before,
+    after: service.after,
+    onError: service.onError
+  };
   const mixin = {};
 
   Object.defineProperty(service, '__hooks', {
@@ -76,20 +79,34 @@ function hookMixin(service){
         // Run through all `after` hooks
         .then(processHooks.bind(this, this.__hooks.after[method]))
         // Finally, return the result
-        .then(hookObject => hookObject.result);
+        .then(hookObject => hookObject.result)
+        .catch(error => {
+          const errorHook = Object.assign({}, error.hook || hookObject, {
+            error
+          });
+
+          return processHooks
+            .call(this, this.__hooks.onError[method], errorHook)
+            .then(hook => Promise.reject(hook.error));
+        });
     };
   });
 
   service.mixin(mixin);
 
   // Before hooks that were registered in the service
-  if(oldBefore) {
-    service.before(oldBefore);
+  if(old.before) {
+    service.before(old.before);
   }
 
   // After hooks that were registered in the service
-  if(oldAfter) {
-    service.after(oldAfter);
+  if(old.after) {
+    service.after(old.after);
+  }
+
+  // onError
+  if(old.onError) {
+    service.onError(old.onError);
   }
 }
 

--- a/test/after.test.js
+++ b/test/after.test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import feathers from 'feathers';
 
-import hooks from '../lib/hooks';
+import hooks from '../src/hooks';
 
 describe('.after hooks', () => {
   describe('function(hook)', () => {

--- a/test/onerror.test.js
+++ b/test/onerror.test.js
@@ -1,0 +1,129 @@
+import assert from 'assert';
+import feathers from 'feathers';
+
+import hooks from '../src/hooks';
+
+describe('.onError hooks', () => {
+  describe('on direct service method errors', () => {
+    const errorMessage = 'Something else went wrong';
+    const app = feathers().configure(hooks()).use('/dummy', {
+      get() {
+        return Promise.reject(new Error('Something went wrong'));
+      }
+    });
+    const service = app.service('dummy');
+
+    afterEach(() => service.__hooks.onError.get.pop());
+
+    it('basic onError hook', done => {
+      service.onError({
+        get(hook) {
+          assert.equal(hook.id, 'test');
+          assert.equal(hook.method, 'get');
+          assert.equal(hook.app, app);
+          assert.equal(hook.error.message, 'Something went wrong');
+        }
+      });
+
+      service.get('test').then(() => {
+        done(new Error('Should never get here'));
+      }).catch(() => done());
+    });
+
+    it('can change the error', () => {
+      service.onError({
+        get(hook) {
+          hook.error = new Error(errorMessage);
+        }
+      });
+
+      return service.get('test').catch(error => {
+        assert.equal(error.message, errorMessage);
+      });
+    });
+
+    it('throwing an error', () => {
+      service.onError({
+        get() {
+          throw new Error(errorMessage);
+        }
+      });
+
+      return service.get('test').catch(error => {
+        assert.equal(error.message, errorMessage);
+      });
+    });
+
+    it('rejecting a promise', () => {
+      service.onError({
+        get() {
+          return Promise.reject(new Error(errorMessage));
+        }
+      });
+
+      return service.get('test').catch(error => {
+        assert.equal(error.message, errorMessage);
+      });
+    });
+
+    it('calling `next` with error', () => {
+      service.onError({
+        get(hook, next) {
+          next(new Error(errorMessage));
+        }
+      });
+
+      return service.get('test').catch(error => {
+        assert.equal(error.message, errorMessage);
+      });
+    });
+  });
+
+  describe('error in hooks', () => {
+    const errorMessage = 'before hook broke';
+
+    let app, service;
+
+    beforeEach(() => {
+      app = feathers().configure(hooks()).use('/dummy', {
+        get(id) {
+          return Promise.resolve({
+            id, text: `You have to do ${id}`
+          });
+        }
+      });
+
+      service = app.service('dummy');
+    });
+
+    it('error in before hook', done => {
+      service.before(function() {
+        throw new Error(errorMessage);
+      }).onError(function(hook) {
+        assert.equal(hook.type, 'before', 'Original hook still set');
+        assert.equal(hook.id, 'dishes');
+        assert.equal(hook.error.message, errorMessage);
+        done();
+      });
+
+      service.get('dishes').then(done);
+    });
+
+    it('error in after hook', done => {
+      service.after(function() {
+        throw new Error(errorMessage);
+      }).onError(function(hook) {
+        assert.equal(hook.type, 'after', 'Original hook still set');
+        assert.equal(hook.id, 'dishes');
+        assert.deepEqual(hook.result, {
+          id: 'dishes',
+          text: 'You have to do dishes'
+        });
+        assert.equal(hook.error.message, errorMessage);
+        done();
+      });
+
+      service.get('dishes').then(done);
+    });
+  });
+});

--- a/test/onerror.test.js
+++ b/test/onerror.test.js
@@ -160,5 +160,20 @@ describe('.onError hooks', () => {
 
       service.get('dishes').then(done);
     });
+
+    it('uses the current hook object if thrown in a hook and sets hook.original', done => {
+      service.after(function(hook) {
+        hook.modified = true;
+
+        throw new Error(errorMessage);
+      }).onError(function(hook) {
+        assert.ok(hook.modified);
+        assert.equal(hook.original.type, 'after');
+
+        done();
+      });
+
+      service.get('laundry').then(done);
+    });
   });
 });

--- a/test/onerror.test.js
+++ b/test/onerror.test.js
@@ -18,6 +18,7 @@ describe('.onError hooks', () => {
     it('basic onError hook', done => {
       service.onError({
         get(hook) {
+          assert.equal(hook.type, 'onError');
           assert.equal(hook.id, 'test');
           assert.equal(hook.method, 'get');
           assert.equal(hook.app, app);
@@ -100,7 +101,9 @@ describe('.onError hooks', () => {
       service.before(function() {
         throw new Error(errorMessage);
       }).onError(function(hook) {
-        assert.equal(hook.type, 'before', 'Original hook still set');
+        assert.equal(hook.error.hook.type, 'before',
+          'Original hook still set'
+        );
         assert.equal(hook.id, 'dishes');
         assert.equal(hook.error.message, errorMessage);
         done();
@@ -113,7 +116,9 @@ describe('.onError hooks', () => {
       service.after(function() {
         throw new Error(errorMessage);
       }).onError(function(hook) {
-        assert.equal(hook.type, 'after', 'Original hook still set');
+        assert.equal(hook.error.hook.type, 'after',
+          'Original hook still set'
+        );
         assert.equal(hook.id, 'dishes');
         assert.deepEqual(hook.result, {
           id: 'dishes',

--- a/test/onerror.test.js
+++ b/test/onerror.test.js
@@ -78,6 +78,36 @@ describe('.onError hooks', () => {
         assert.equal(error.message, errorMessage);
       });
     });
+
+    it('can chain multiple hooks', () => {
+      service.onError({
+        get: [
+          function(hook) {
+            hook.error = new Error(errorMessage);
+            hook.error.first = true;
+          },
+
+          function(hook) {
+            hook.error.second = true;
+
+            return Promise.resolve(hook);
+          },
+
+          function(hook, next) {
+            hook.error.third = true;
+
+            next();
+          }
+        ]
+      });
+
+      return service.get('test').catch(error => {
+        assert.equal(error.message, errorMessage);
+        assert.ok(error.first);
+        assert.ok(error.second);
+        assert.ok(error.third);
+      });
+    });
   });
 
   describe('error in hooks', () => {


### PR DESCRIPTION
This allows to register `onError` hooks the same way as `before` and `after` hooks:

```js
const app = feathers().configure(hooks()).use('/dummy', {
  get() {
    return Promise.reject(new Error('Something went wrong'));
  }
});
const service = app.service('dummy');

service.onError(function(hook) {
  // hook.type === 'onError'
  // hook.error === Error('Something went wrong')
  throw new Error('This is another error');
});

service.get().catch(e => console.error(e));
```

Closes #83