### PR TITLE
Implement .hooks service method

### DIFF
--- a/src/commons.js
+++ b/src/commons.js
@@ -1,5 +1,3 @@
-import { hooks as utils } from 'feathers-commons';
-
 export function isHookObject(hookObject) {
   return typeof hookObject === 'object' &&
     typeof hookObject.method === 'string' &&
@@ -47,37 +45,15 @@ export function processHooks(hooks, initialHookObject) {
   });
 }
 
-export function addHookMethod(service, type, methods) {
-  // Initialize properties where hook functions are stored
-  service.__hooks[type] = {};
-  methods.forEach(method => {
-    if(typeof service[method] === 'function') {
-      service.__hooks[type][method] = [];
-    }
-  });
+export function addHookTypes(service, methods, ... types) {
+  types.forEach(type => {
+    // Initialize properties where hook functions are stored
+    service.__hooks[type] = {};
 
-  // mixin the method (.before or .after)
-  service.mixin({
-    [type](obj) {
-      const hooks = utils.convertHookData(obj);
-
-      methods.forEach(method => {
-        if(typeof this[method] !== 'function') {
-          return;
-        }
-
-        const myHooks = this.__hooks[type][method];
-
-        if(hooks.all) {
-          myHooks.push.apply(myHooks, hooks.all);
-        }
-
-        if(hooks[method]) {
-          myHooks.push.apply(myHooks, hooks[method]);
-        }
-      });
-
-      return this;
-    }
+    methods.forEach(method => {
+      if(typeof service[method] === 'function') {
+        service.__hooks[type][method] = [];
+      }
+    });
   });
 }


### PR DESCRIPTION
This pull request adds a `.hooks` service method that supports any kind of hook (without having to add each as a service method itself). `service.before` and `service.after` are kept for backwards compatibility. They can be used and chained like all hooks already used. Basically any `service.before(anything);` becomes `service.hooks({ before: anything })`. Some examples:

```js
const todos = app.service('todos');

// before and after multiple hooks
todos.hooks({
  before: {
    all: [ beforeAllHooks ],
    create: [ beforeCreate ]
    // etc.
  },

  after: {
    all: [],
    create: []
    // etc.
  },

  error: { // new on error hooks
    all: [],
    create: []
    // etc.
  }
});

// before create single hook
todos.hooks({
  before: {
    create
  }
});

// before all hook
todos.hooks({
  before(hook) {

  }
});
```
