### PR TITLE
app.hooks global hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   "dependencies": {
     "feathers-commons": "^0.7.8",
     "feathers-errors": "^2.0.1",
-    "feathers-hooks-common": "^2.0.0"
+    "feathers-hooks-common": "^2.0.0",
+    "uberproto": "^1.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",

--- a/src/commons.js
+++ b/src/commons.js
@@ -1,3 +1,5 @@
+import { each, hooks as utils } from 'feathers-commons';
+
 export function isHookObject (hookObject) {
   return typeof hookObject === 'object' &&
     typeof hookObject.method === 'string' &&
@@ -45,15 +47,65 @@ export function processHooks (hooks, initialHookObject) {
   });
 }
 
-export function addHookTypes (service, methods, ...types) {
+export function addHookTypes (target, types = ['before', 'after', 'error']) {
+  Object.defineProperty(target, '__hooks', {
+    value: {}
+  });
+
   types.forEach(type => {
     // Initialize properties where hook functions are stored
-    service.__hooks[type] = {};
-
-    methods.forEach(method => {
-      if (typeof service[method] === 'function') {
-        service.__hooks[type][method] = [];
-      }
-    });
+    target.__hooks[type] = {};
   });
+}
+
+export function getHooks (app, service, type, method, appLast = false) {
+  const appHooks = app.__hooks[type][method] || [];
+  const serviceHooks = service.__hooks[type][method] || [];
+
+  if (appLast) {
+    return serviceHooks.concat(appHooks);
+  }
+
+  return appHooks.concat(serviceHooks);
+}
+
+export function baseMixin (methods, ...objs) {
+  const mixin = {
+    hooks (allHooks) {
+      each(allHooks, (obj, type) => {
+        if (!this.__hooks[type]) {
+          throw new Error(`'${type}' is not a valid hook type`);
+        }
+
+        const hooks = utils.convertHookData(obj);
+
+        each(hooks, (value, method) => {
+          if (method !== 'all' && methods.indexOf(method) === -1) {
+            throw new Error(`'${method}' is not a valid hook method`);
+          }
+        });
+
+        methods.forEach(method => {
+          if (typeof this[method] !== 'function') {
+            return;
+          }
+
+          const myHooks = this.__hooks[type][method] ||
+            (this.__hooks[type][method] = []);
+
+          if (hooks.all) {
+            myHooks.push.apply(myHooks, hooks.all);
+          }
+
+          if (hooks[method]) {
+            myHooks.push.apply(myHooks, hooks[method]);
+          }
+        });
+      });
+
+      return this;
+    }
+  };
+
+  return Object.assign(mixin, ...objs);
 }

--- a/src/commons.js
+++ b/src/commons.js
@@ -86,7 +86,7 @@ export function baseMixin (methods, ...objs) {
         });
 
         methods.forEach(method => {
-          if (typeof this[method] !== 'function') {
+          if (!(hooks[method] || hooks.all)) {
             return;
           }
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -16,6 +16,10 @@ describe('app.hooks', () => {
           }
 
           return Promise.resolve({ id, params });
+        },
+
+        create (data, params) {
+          return Promise.resolve({ data, params });
         }
       });
   });
@@ -26,16 +30,26 @@ describe('app.hooks', () => {
 
   describe('app.hooks({ before })', () => {
     it('basic app before hook', () => {
+      const service = app.service('todos');
+
       app.hooks({
         before (hook) {
           hook.params.ran = true;
         }
       });
 
-      return app.service('todos').get('test').then(result => {
+      return service.get('test').then(result => {
         assert.deepEqual(result, {
           id: 'test',
           params: { ran: true }
+        });
+
+        const data = { test: 'hi' };
+
+        return service.create(data).then(result => {
+          assert.deepEqual(result, {
+            data, params: { ran: true }
+          });
         });
       });
     });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,158 @@
+import assert from 'assert';
+import feathers from 'feathers';
+
+import hooks from '../src/hooks';
+
+describe('app.hooks', () => {
+  let app;
+
+  beforeEach(() => {
+    app = feathers()
+      .configure(hooks())
+      .use('/todos', {
+        get (id, params) {
+          if (id === 'error') {
+            return Promise.reject(new Error('Something went wrong'));
+          }
+
+          return Promise.resolve({ id, params });
+        }
+      });
+  });
+
+  it('app has the .hooks method', () => {
+    assert.equal(typeof app.hooks, 'function');
+  });
+
+  describe('app.hooks({ before })', () => {
+    it('basic app before hook', () => {
+      app.hooks({
+        before (hook) {
+          hook.params.ran = true;
+        }
+      });
+
+      return app.service('todos').get('test').then(result => {
+        assert.deepEqual(result, {
+          id: 'test',
+          params: { ran: true }
+        });
+      });
+    });
+
+    it('app before hooks always run first', () => {
+      app.service('todos').hooks({
+        before (hook) {
+          hook.params.order.push('service.before');
+        }
+      });
+
+      app.service('todos').hooks({
+        before (hook) {
+          hook.params.order.push('service.before 1');
+        }
+      });
+
+      app.hooks({
+        before (hook) {
+          hook.params.order = [];
+          hook.params.order.push('app.before');
+        }
+      });
+
+      return app.service('todos').get('test').then(result => {
+        assert.deepEqual(result, {
+          id: 'test',
+          params: {
+            order: [ 'app.before', 'service.before', 'service.before 1' ]
+          }
+        });
+      });
+    });
+  });
+
+  describe('app.hooks({ after })', () => {
+    it('basic app after hook', () => {
+      app.hooks({
+        after (hook) {
+          hook.result.ran = true;
+        }
+      });
+
+      return app.service('todos').get('test').then(result => {
+        assert.deepEqual(result, {
+          id: 'test',
+          params: {},
+          ran: true
+        });
+      });
+    });
+
+    it('app after hooks always run last', () => {
+      app.hooks({
+        after (hook) {
+          hook.result.order.push('app.after');
+        }
+      });
+
+      app.service('todos').hooks({
+        after (hook) {
+          hook.result.order = [];
+          hook.result.order.push('service.after');
+        }
+      });
+
+      app.service('todos').hooks({
+        after (hook) {
+          hook.result.order.push('service.after 1');
+        }
+      });
+
+      return app.service('todos').get('test').then(result => {
+        assert.deepEqual(result, {
+          id: 'test',
+          params: {},
+          order: [ 'service.after', 'service.after 1', 'app.after' ]
+        });
+      });
+    });
+  });
+
+  describe('app.hooks({ error })', () => {
+    it('basic app error hook', () => {
+      app.hooks({
+        error (hook) {
+          hook.error = new Error('App hook ran');
+        }
+      });
+
+      return app.service('todos').get('error').catch(error => {
+        assert.equal(error.message, 'App hook ran');
+      });
+    });
+
+    it('app error hooks always run last', () => {
+      app.hooks({
+        error (hook) {
+          hook.error = new Error(`${hook.error.message} app.after`);
+        }
+      });
+
+      app.service('todos').hooks({
+        error (hook) {
+          hook.error = new Error(`${hook.error.message} service.after`);
+        }
+      });
+
+      app.service('todos').hooks({
+        error (hook) {
+          hook.error = new Error(`${hook.error.message} service.after 1`);
+        }
+      });
+
+      return app.service('todos').get('error').catch(error => {
+        assert.equal(error.message, 'Something went wrong service.after service.after 1 app.after');
+      });
+    });
+  });
+});

--- a/test/bundled.test.js
+++ b/test/bundled.test.js
@@ -645,7 +645,7 @@ describe('Bundled feathers hooks', () => {
   describe('populate', () => {
     let app;
 
-    before(() => {
+    beforeEach(() => {
       app = feathers()
         .configure(rest())
         .configure(hooks())
@@ -686,7 +686,6 @@ describe('Bundled feathers hooks', () => {
           user: { id: 10, name: 'user 10' },
           id: 0
         });
-        service.__hooks.after.create.pop();
       });
     });
 
@@ -706,9 +705,8 @@ describe('Bundled feathers hooks', () => {
           text: 'A todo',
           userId: 10,
           user: { id: 10, name: 'user 10' },
-          id: 1
+          id: 0
         });
-        service.__hooks.after.create.pop();
       });
     });
 
@@ -727,9 +725,8 @@ describe('Bundled feathers hooks', () => {
         assert.deepEqual(todo, {
           text: 'A todo',
           groups: [ { id: 12, name: 'group 12' }, { id: 13, name: 'group 13' } ],
-          id: 2
+          id: 0
         });
-        service.__hooks.after.create.pop();
       });
     });
 
@@ -755,9 +752,8 @@ describe('Bundled feathers hooks', () => {
           text: 'Queried todo',
           userId: 15,
           user: { id: 15, name: 'user 15' },
-          id: 3
+          id: 0
         }]);
-        service.__hooks.after.find.pop();
       });
     });
   });


### PR DESCRIPTION
This pull request adds `app.hooks` which allows to register global `before`, `after` and `error` hooks that run for every service.

__Note:__ App `before` hooks will always run before all other service `before` hooks. App `after` and `error` hooks will run after all service specific `after` and `error` hooks.

For example logging the duration of every service method execution can be done like this:

```js
app.hooks({
  before(hook) {
    hook.start = new Date().getTime();
  },

  after(hook) {
    const duration = new Date().getTime() - hook.start;

    console.log(`${hook.method} execution took ${duration}ms`);
  }
});
```

A global service error handler that logs the error can look like this:

```js
app.hooks({
  error(hook) {
    console.error(`Error in ${hook.method}`, error);
  }
});
```

Also closes #119