### PR TITLE
Adding hook.path and hook.service

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "feathers-commons": "^0.8.0",
+    "feathers-commons": "^0.8.6",
     "feathers-hooks-common": "^2.0.0",
     "uberproto": "^1.2.0"
   },

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -40,15 +40,17 @@ function hookMixin (service) {
       const service = this;
       // A reference to the original method
       const _super = this._super.bind(this);
-      // Create the hook object that gets passed through
-      const hookObject = utils.hookObject(method, 'before', arguments, {
+      // Additional data to add to the hook object
+      const hookData = {
         app,
         service,
         get path () {
           return Object.keys(app.services)
             .find(path => app.services[path] === service);
         }
-      });
+      };
+      // Create the hook object that gets passed through
+      const hookObject = utils.hookObject(method, 'before', arguments, hookData);
       // Get all hooks
       const hooks = {
         // For before hooks the app hooks will run first

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -37,10 +37,18 @@ function hookMixin (service) {
     }
 
     mixin[method] = function () {
+      const service = this;
       // A reference to the original method
       const _super = this._super.bind(this);
       // Create the hook object that gets passed through
-      const hookObject = utils.hookObject(method, 'before', arguments, app);
+      const hookObject = utils.hookObject(method, 'before', arguments, {
+        app,
+        service,
+        get path () {
+          return Object.keys(app.services)
+            .find(path => app.services[path] === service);
+        }
+      });
       // Get all hooks
       const hooks = {
         // For before hooks the app hooks will run first

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -77,6 +77,32 @@ describe('feathers-hooks', () => {
     service.create({ test: true });
   });
 
+  it('has hook.app, hook.service and hook.path', done => {
+    const app = feathers().configure(hooks()).use('/dummy', {
+      get (id) {
+        return Promise.resolve({ id });
+      }
+    });
+
+    const service = app.service('dummy');
+
+    service.hooks({
+      before (hook) {
+        try {
+          assert.equal(this, service);
+          assert.equal(hook.service, service);
+          assert.equal(hook.app, app);
+          assert.equal(hook.path, 'dummy');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }
+    });
+
+    service.get('test');
+  });
+
   it('does not error when result is null', () => {
     const app = feathers().configure(hooks()).use('/dummy', {
       get (id, params, callback) {


### PR DESCRIPTION
Adds to the hook object:

- `hook.path` which contains the current service path. This is implemented as a getter so it only runs when actually needed.
- `hook.service` which is the same as `this` in a hook but it seemed like people got tripped up by it and `this` also does not work when using arrow functions.