### PR TITLE
Additional hook typedefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,38 @@
+import * as feathers from 'feathers';
 
+interface Hook {
+  <T>(hook: HookProps<T>): Promise<any> | void;
+}
 
-declare function configure(): () =>void;
-declare namespace configure{}
-export = configure;
+interface HookProps<T> {
+  method?: string;
+  type: 'before' | 'after';
+  params?: any;
+  data?: T;
+  result?: T;
+  app?: feathers.Application;
+}
+
+interface HookMap {
+  all?: Hook | Hook[];
+  find?: Hook | Hook[];
+  get?: Hook | Hook[];
+  create?: Hook | Hook[];
+  update?: Hook | Hook[];
+  patch?: Hook | Hook[];
+  remove?: Hook | Hook[];
+}
+
+type HookType = HookMap | ((hooks: HookMap) => void);
+
+declare module 'feathers' {
+  interface Service<T> {
+    before: HookType;
+    after: HookType;
+  }
+}
+
+declare function hooks(): () => void;
+
+declare namespace hooks{}
+export = hooks;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,38 +1,37 @@
 import * as feathers from 'feathers';
 
-interface Hook {
-  <T>(hook: HookProps<T>): Promise<any> | void;
-}
-
-interface HookProps<T> {
-  method?: string;
-  type: 'before' | 'after';
-  params?: any;
-  data?: T;
-  result?: T;
-  app?: feathers.Application;
-}
-
-interface HookMap {
-  all?: Hook | Hook[];
-  find?: Hook | Hook[];
-  get?: Hook | Hook[];
-  create?: Hook | Hook[];
-  update?: Hook | Hook[];
-  patch?: Hook | Hook[];
-  remove?: Hook | Hook[];
-}
-
-type HookType = HookMap | ((hooks: HookMap) => void);
-
 declare module 'feathers' {
   interface Service<T> {
-    before: HookType;
-    after: HookType;
+    before(hooks: hooks.HookMap);
+    after(hooks: hooks.HookMap);
   }
 }
 
 declare function hooks(): () => void;
 
-declare namespace hooks{}
+declare namespace hooks {
+  interface Hook {
+    <T>(hook: HookProps<T>): Promise<any> | void;
+  }
+
+  interface HookProps<T> {
+    method?: string;
+    type: 'before' | 'after';
+    params?: any;
+    data?: T;
+    result?: T;
+    app?: feathers.Application;
+  }
+
+  interface HookMap {
+    all?: Hook | Hook[];
+    find?: Hook | Hook[];
+    get?: Hook | Hook[];
+    create?: Hook | Hook[];
+    update?: Hook | Hook[];
+    patch?: Hook | Hook[];
+    remove?: Hook | Hook[];
+  }
+}
+
 export = hooks;


### PR DESCRIPTION
Main goal is to add `before()` and `after()` methods to service instances, but ended up adding more things.  

Right now, before and after must be used as methods, and not properties.  Could be improved later.

Related to #135 

This gist:  https://gist.github.com/harangue/9d4ed79118e2656f5e3d2d699296ed36 is the main source.