### PR TITLE
Fixed issue with __hooks being overwritten when reusing service

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -8,6 +8,10 @@ function isPromise (result) {
 }
 
 function hookMixin (service) {
+  if (typeof service.hooks === 'function') {
+    return;
+  }
+
   const app = this;
   const methods = app.methods;
   const old = {


### PR DESCRIPTION
Fixes issue with __hooks being overwritten when service is re-used.

```
app.use('/me/projects', app.service('/projects'))
```
Throws an error
```
Object.defineProperty(target, '__hooks', {
         ^
TypeError: Cannot redefine property: __hooks
```
Hooks should not try to redefine that object if it already exists.