### PR TITLE
TypeScript: HookProps.type: add 'error'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace hooks {
 
   interface HookProps<T> {
     method?: string;
-    type: 'before' | 'after';
+    type: 'before' | 'after' | 'error';
     params?: any;
     data?: T;
     result?: T;


### PR DESCRIPTION
- [x] Tell us about the problem your pull request is solving. - This is used in feathers-cli's generated app in src/hooks/logger, which contains a `hook.type === 'error'` check.
- [x] Are there any open issues that are related to this? - not afaict
- [x] Is this PR dependent on PRs in other repos? - no