### PR TITLE
Update README to point at new documentation location

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-Please refer to the [Feathers hooks documentation](http://docs.feathersjs.com/hooks/readme.html) for more details on:
+Please refer to the [Feathers hooks documentation](https://docs.feathersjs.com/api/hooks.html) for more details on:
 
 - The philosophy behind hooks
 - How you can use hooks


### PR DESCRIPTION
This is a very minor change. I've been working on a feathers-based API for the last few weeks (it's awesome!) and have noticed a few links still pointing to the legacy documentation. I assume you want them all to point to the latest documentation so here is a pull-request to take care of that for this README.