### PR TITLE
Allow errors to be swallowed in error hooks

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -100,13 +100,14 @@ function hookMixin (service) {
         .catch(error => {
           const errorHook = Object.assign({}, error.hook || hookObject, {
             type: 'error',
+            result: null,
             original: error.hook,
             error
           });
 
           return processHooks
             .call(this, hooks.error, errorHook)
-            .then(hook => Promise.reject(hook.error));
+            .then(hook => hook.result || Promise.reject(hook.error));
         });
     };
   });

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -120,6 +120,22 @@ describe('error hooks', () => {
         assert.ok(error.third);
       });
     });
+
+    it('setting `hook.result` will return result', () => {
+      const data = {
+        message: 'It worked'
+      };
+
+      service.hooks({
+        error (hook) {
+          hook.result = data;
+          return Promise.resolve(hook);
+        }
+      });
+
+      return service.get(10)
+        .then(result => assert.deepEqual(result, data));
+    });
   });
 
   describe('error in hooks', () => {
@@ -167,7 +183,7 @@ describe('error hooks', () => {
             'Original hook still set'
           );
           assert.equal(hook.id, 'dishes');
-          assert.deepEqual(hook.result, {
+          assert.deepEqual(hook.original.result, {
             id: 'dishes',
             text: 'You have to do dishes'
           });


### PR DESCRIPTION
For feathersjs/feathers-hooks#151

This is (mostly) just copying the necessary parts and test from @daffl's fix found in the main project:
https://github.com/feathersjs/feathers/pull/621/files

#### Use case:
I have a create user (sign up) service that returns just the email that was entered and we show a message that says something like `Email sent! Please check ${response.email} for additional information.`

However, if the user already exists then the service returns an error - which is good if the server or an admin user runs it.

BUT if the request is from a non-admin end user, we need to return the original non-error reply as if the email didn't exist. (so we don't leak information to anyone maliciously using the form about who's registered)

In order to do that in a clean way, we need to conditionally swallow the error in an error hook.

#### Breaking change:
If `hook.result` is set and then an error happens, `hook.result` will now be `null`. The original result can still be accessed from `hook.original.result`.