### PR TITLE
Fix TypeScript declarations.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,17 @@
-import * as feathers from "feathers-typescript-fix";
+import * as feathers from "feathers";
 
 declare function hooks(): () => void;
+
+declare module "feathers" {
+    interface Service<T> {
+        before(hooks: hooks.HookMap): Application;
+        after(hooks: hooks.HookMap): Application;
+        hooks(hooks: hooks.HooksObject): Application;
+    }
+    interface Application {
+        hooks(hooks: hooks.HooksObject): Application;
+    }
+}
 
 declare namespace hooks {
     interface Hook {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,52 +1,40 @@
-import * as feathers from 'feathers';
-
-declare module 'feathers' {
-  interface Application {
-    hooks(hooks: hooks.HooksObject): Application;
-  }
-
-  interface Service<T> {
-    before(hooks: hooks.HookMap): Application;
-    after(hooks: hooks.HookMap): Application;
-    hooks(hooks: hooks.HooksObject): Application;
-  }
-}
+import * as feathers from "feathers-typescript-fix";
 
 declare function hooks(): () => void;
 
 declare namespace hooks {
-  interface Hook {
-    <T>(hook: HookProps<T>): Promise<any> | void;
-  }
+    interface Hook {
+        <T>(hook: HookProps<T>): Promise<any> | void;
+    }
 
-  interface HookProps<T> {
-    app?: feathers.Application;
-    data?: T;
-    error?: any;
-    id?: string | number;
-    method?: string;
-    params?: any;
-    path?: string;
-    result?: T;
-    service: feathers.Service<T>;
-    type: 'before' | 'after' | 'error';
-  }
+    interface HookProps<T> {
+        app?: feathers.Application;
+        data?: T;
+        error?: any;
+        id?: string | number;
+        method?: string;
+        params?: any;
+        path?: string;
+        result?: T;
+        service: feathers.Service<T>;
+        type: "before" | "after" | "error";
+    }
 
-  interface HookMap {
-    all?: Hook | Hook[];
-    find?: Hook | Hook[];
-    get?: Hook | Hook[];
-    create?: Hook | Hook[];
-    update?: Hook | Hook[];
-    patch?: Hook | Hook[];
-    remove?: Hook | Hook[];
-  }
+    interface HookMap {
+        all?: Hook | Hook[];
+        find?: Hook | Hook[];
+        get?: Hook | Hook[];
+        create?: Hook | Hook[];
+        update?: Hook | Hook[];
+        patch?: Hook | Hook[];
+        remove?: Hook | Hook[];
+    }
 
-  interface HooksObject {
-    before?: HookMap;
-    after?: HookMap;
-    error?: HookMap;
-  }
+    interface HooksObject {
+        before?: HookMap;
+        after?: HookMap;
+        error?: HookMap;
+    }
 }
 
 export = hooks;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'feathers' {
     hooks(hooks: hooks.HooksObject): Application;
   }
 
-  interface Service<T extends any> {
+  interface Service<T> {
     before(hooks: hooks.HookMap): Application;
     after(hooks: hooks.HookMap): Application;
     hooks(hooks: hooks.HooksObject): Application;


### PR DESCRIPTION
### Summary

TypeScript 2.5.2 in strict mode throws many errors on the built-in `index.d.ts` declarations. It doesn't seem possible to prevent TypeScript from throwing these errors (the `exclude` option doesn't work). I feel it's bad form to "ignore" errors, so I'd rather seem them patched in the upstream source.